### PR TITLE
Add exception/error message when OTP is enabled on an account.

### DIFF
--- a/custom_components/resmed_myair/client/myair_client.py
+++ b/custom_components/resmed_myair/client/myair_client.py
@@ -8,6 +8,12 @@ class AuthenticationError(Exception):
     pass
 
 
+class TwoFactorNotSupportedError(Exception):
+    """This error is thrown when 2-factor/OTP is enabled, this is not yet supported"""
+
+    pass
+
+
 class MyAirConfig(NamedTuple):
     """
     This is our config for logging into MyAir

--- a/custom_components/resmed_myair/config_flow.py
+++ b/custom_components/resmed_myair/config_flow.py
@@ -17,6 +17,7 @@ from .client.myair_client import (
     MyAirConfig,
     MyAirDevice,
     AuthenticationError,
+    TwoFactorNotSupportedError,
 )
 from .client import get_client
 
@@ -69,6 +70,8 @@ class MyAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             except AuthenticationError:
                 errors["base"] = "authentication_error"
+            except TwoFactorNotSupportedError:
+                errors["base"] = "two_factor_not_supported"
 
         return self.async_show_form(
             step_id="user",

--- a/custom_components/resmed_myair/strings.json
+++ b/custom_components/resmed_myair/strings.json
@@ -14,7 +14,8 @@
         },
         "error": {
             "already_configured": "Device is already configured",
-            "authentication_error": "Invalid username or password. Please verify with myair2.resmed.com"
+            "authentication_error": "Invalid username or password. Please verify with myair2.resmed.com",
+            "two_factor_not_supported": "2-factor auth is enabled on your account. This is not supported by this integration. Tracking at https://github.com/prestomation/resmed_myair_sensors/issues/16"
         },
         "abort": {
             "already_configured": "Device is already configured"

--- a/custom_components/resmed_myair/translations/en.json
+++ b/custom_components/resmed_myair/translations/en.json
@@ -14,7 +14,8 @@
         },
         "error": {
             "already_configured": "Device is already configured",
-            "authentication_error": "Invalid username or password. Please verify with myair2.resmed.com"
+            "authentication_error": "Invalid username or password. Please verify with myair2.resmed.com",
+            "two_factor_not_supported": "2-factor auth is enabled on your account. This is not supported by this integration. Tracking at https://github.com/prestomation/resmed_myair_sensors/issues/16"
         },
         "abort": {
             "already_configured": "Device is already configured"


### PR DESCRIPTION
Users from some countries, like France, have OTP-by-mail turned on by ResMed with no way to disable.

Detection for this is added in this change, along with a useful error message in the config flow