### PR TITLE
Try this again: Don't specify version for pyJWT

### DIFF
--- a/custom_components/resmed_myair/manifest.json
+++ b/custom_components/resmed_myair/manifest.json
@@ -4,7 +4,7 @@
   "dependencies": [],
   "requirements": [
     "beautifulsoup4",
-    "PyJWT==2.3.0"
+    "PyJWT"
   ],
   "iot_class": "cloud_polling",
   "version": "0.1.0",


### PR DESCRIPTION
Tested on my home's 2022.03.8 install and 2022.4b in my dev environment.

It broke on one or the other when specifying a more specific version