### PR TITLE
Change to async_forward_entry_setups

### DIFF
--- a/custom_components/resmed_myair/__init__.py
+++ b/custom_components/resmed_myair/__init__.py
@@ -20,7 +20,7 @@ PLATFORMS: List[str] = ["sensor"]
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
-    hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
2023-02-01 21:06:44.621 WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that called async_setup_platforms instead of awaiting async_forward_entry_setups; this will fail in version 2023.3. Please report issue to the custom integration author for resmed_myair using this method at custom_components/resmed_myair/__init__.py, line 23: hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)