### PR TITLE
Get Dependabot to also upgrade GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
     interval: daily
     time: "06:00"
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: /
+  groups:
+    github-actions:
+      patterns:
+        - "*"  # Group all Actions updates into a single larger pull request
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Keep GitHub Actions up to date with GitHub's Dependabot to clean up the warnings at the bottom right of
https://github.com/prestomation/resmed_myair_sensors/actions/runs/5595871057
* https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem