### PR TITLE
rmdappversion header for API Call chagned

### DIFF
--- a/custom_components/resmed_myair/client/new_client.py
+++ b/custom_components/resmed_myair/client/new_client.py
@@ -166,7 +166,7 @@ class RESTClient(MyAirClient):
             "rmdhandsetmodel": "Chrome",
             "rmdhandsetosversion": "96.0.4664.110",
             "rmdproduct": "myAir",
-            "rmdappversion": "1.0",
+            "rmdappversion": "1.0.0",
             "rmdhandsetplatform": "Web",
             "rmdcountry": country_code,
             "accept-language": "en-US,en;q=0.9",


### PR DESCRIPTION
The US endpoint now requires *1.0.0* instead of just *1.0* for the **rmdappversion**.

They literally just now require an additional ".0".

Here are the screenshots from Postman showing this.
If you have rmdappversion set to "1.0" you get an error, which results in a "NoneType" object, because of an unknown error, and home assistant freaks out.
![image](https://github.com/prestomation/resmed_myair_sensors/assets/6484397/3dd55227-3fbf-4892-a90e-d7a71ba4335d)

However... changing to "1.0.0" fixes the issue:
![image](https://github.com/prestomation/resmed_myair_sensors/assets/6484397/62802203-bfe3-4a10-b023-02cf5624cbbe)
