### PR TITLE
Minor revisions

### DIFF
--- a/custom_components/resmed_myair/client/rest_client.py
+++ b/custom_components/resmed_myair/client/rest_client.py
@@ -195,8 +195,10 @@ class RESTClient(MyAirClient):
         for header in cookie_headers:
             cookie = SimpleCookie(header)
             for key, morsel in cookie.items():
-                if key.lower() in {"dt", "sid"}:
-                    cookies[key] = morsel.value
+                k = key.lower()
+                if k in {"dt", "sid"}:
+                    norm = "DT" if k == "dt" else "sid"
+                    cookies[norm] = morsel.value
         _LOGGER.debug("[extract_and_update_cookies] extracted cookies: %s", cookies)
 
         if cookies.get("DT") and cookies.get("DT") != self._cookie_dt:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -138,8 +138,10 @@ async def test_async_step_verify_mfa_error(
     # RESTClient path should set a specific 'base' error; non-RESTClient may only return a generic errors dict
     if is_restclient:
         assert result["errors"].get("base") == "mfa_error"
+        assert result["step_id"] == "verify_mfa"
     else:
         assert "base" not in result["errors"]
+        assert result["step_id"] == "verify_mfa"
 
 
 @pytest.mark.asyncio
@@ -782,8 +784,8 @@ async def test_async_step_reauth_verify_mfa_user_input_and_restclient(
             )
         ),
     )
-    # Patch device_token() on the client to return a token
-    flow._client.device_token.return_value = "token"
+    # RESTClient.device_token is a @property; set it directly
+    flow._client.device_token = "token"
 
     # Patch async_abort to just return its arguments for assertion
     flow.async_abort = MagicMock(return_value={"type": "abort", "reason": "reauth_successful"})

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -58,6 +58,8 @@ def test_properties_variants(case, config_na, session):
         (None, None, ["DT=abc; Path=/", "sid=xyz; Path=/"], "abc", "xyz", False),
         # No change if cookies are the same
         ("abc", "xyz", ["DT=abc; Path=/", "sid=xyz; Path=/"], "abc", "xyz", False),
+        # Case-insensitive cookie names should work too
+        (None, None, ["dt=abc; Path=/", "SID=xyz; Path=/"], "abc", "xyz", False),
         # DT was None, should update DT
         (None, "xyz", ["DT=abc; Path=/", "sid=xyz; Path=/"], "abc", "xyz", False),
         # SID changes


### PR DESCRIPTION
This pull request makes several improvements to cookie handling and test coverage in the `resmed_myair` integration. The main focus is on ensuring case-insensitive handling of cookie names, improving test robustness, and clarifying property usage in tests.

**Cookie Handling Improvements:**

* Updated `_extract_and_update_cookies` in `rest_client.py` to handle cookie names case-insensitively and normalize them to `"DT"` or `"sid"` when storing, ensuring consistent internal representation regardless of the case in the incoming headers.

**Test Coverage and Robustness:**

* Added a test case to `test_rest_client.py` to verify that cookie extraction works correctly with case-insensitive cookie names.

**Test Clarity and Correctness:**

* In `test_config_flow.py`, updated assertions in `test_async_step_verify_mfa_error` to always check the `step_id` is `"verify_mfa"`, increasing test clarity and correctness.
* Corrected the way the `device_token` is set in `test_async_step_reauth_verify_mfa_user_input_and_restclient` to reflect its property nature, making the test setup more accurate.