### PR TITLE
Add HA analytics integration usage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # resmed_myair
+[![Integration Usage](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https%3A%2F%2Fanalytics.home-assistant.io%2Fcustom_integrations.json&query=%24.resmed_myair.total)](https://analytics.home-assistant.io/custom_integrations.json)
 
 [![GitHub Downloads][downloads-shield]][releases]
 [![GitHub Latest Downloads][downloads-latest-shield]][releases]


### PR DESCRIPTION
Adds a Shields.io dynamic badge that pulls live install count from the Home Assistant analytics API (https://analytics.home-assistant.io/custom_integrations.json).

Currently shows **974 active installs** for resmed_myair — much more meaningful than GitHub download counts which only track HACS asset downloads.

Badge: `![Integration Usage](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.resmed_myair.total)`

Pattern from dahlb/ha_carrier.