### PR TITLE
Improve docstring coverage

### DIFF
--- a/custom_components/resmed_myair/__init__.py
+++ b/custom_components/resmed_myair/__init__.py
@@ -31,7 +31,15 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Set up from a config entry."""
+    """Create the myAir client, coordinator, and platform entities for an entry.
+
+    Args:
+        hass: Home Assistant instance loading the integration.
+        config_entry: Stored myAir account configuration.
+
+    Returns:
+        ``True`` after the first coordinator refresh and platform setup succeed.
+    """
     _LOGGER.info("Starting ResMed myAir Integration Version: %s", VERSION)
     _LOGGER.debug("[init async_setup_entry] config_entry.data: %s", redact_dict(config_entry.data))
 
@@ -59,7 +67,15 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Migrate old entry."""
+    """Upgrade stored config-entry data between integration schema versions.
+
+    Args:
+        hass: Home Assistant instance that owns the config entry registry.
+        config_entry: Existing myAir entry being loaded.
+
+    Returns:
+        ``True`` after applying any needed migration.
+    """
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version == 1:
@@ -75,7 +91,15 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
+    """Unload myAir platforms for a removed or reloaded config entry.
+
+    Args:
+        hass: Home Assistant instance unloading the integration.
+        entry: myAir config entry being unloaded.
+
+    Returns:
+        Whether Home Assistant unloaded all forwarded platforms successfully.
+    """
     _LOGGER.info("Unloading: %s", redact_dict(entry.data))
     unload_ok: bool = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 

--- a/custom_components/resmed_myair/client/auth.py
+++ b/custom_components/resmed_myair/client/auth.py
@@ -247,7 +247,7 @@ class MyAirAuthSession:
 
     @property
     def cookies(self) -> dict[str, Any]:
-        """Expose cookies through the legacy RESTClient compatibility surface."""
+        """Expose the current Okta cookies without allowing direct mutation."""
         return self._cookies
 
     def set_error_checker(self, checker: _ErrorCheck) -> None:
@@ -274,7 +274,7 @@ class MyAirAuthSession:
 
     @property
     def json_headers(self) -> dict[str, Any]:
-        """Expose default headers for Okta JSON request payloads."""
+        """Expose the JSON headers sent to Okta auth endpoints."""
         return self._json_headers
 
     @json_headers.setter
@@ -326,7 +326,7 @@ class MyAirAuthSession:
         resp_dict: MutableMapping[str, Any],
         initial: bool | None = False,
     ) -> None:
-        """Run the active response validator for an auth request.
+        """Apply the injected response validator to auth and token calls.
 
         Args:
             step: Human-readable auth step name for error messages.
@@ -670,7 +670,7 @@ class MyAirAuthSession:
         return status
 
     async def authn_check(self) -> str:
-        """Run primary Okta auth through the public helper.
+        """Expose primary Okta auth for RESTClient compatibility tests.
 
         Returns:
             Okta status indicating success or MFA requirement.
@@ -874,7 +874,7 @@ class MyAirAuthSession:
                 self._access_token = access_token
 
     async def get_access_token(self, extract_cookies: _CookieUpdate | None = None) -> None:
-        """Run OAuth token exchange through the public helper.
+        """Expose OAuth token exchange for RESTClient compatibility tests.
 
         Args:
             extract_cookies: Optional cookie extractor used by compatibility tests.

--- a/custom_components/resmed_myair/client/auth.py
+++ b/custom_components/resmed_myair/client/auth.py
@@ -67,10 +67,10 @@ def _safe_auth_log_payload(data: Any) -> Any:
 
 
 class MyAirAuthSession:
-    """Encapsulate authentication/session concerns for the myAir REST flow."""
+    """Maintain Okta, OAuth, cookie, and token state for the myAir REST flow."""
 
     def __init__(self, config: MyAirConfig, session: ClientSession) -> None:
-        """Initialize auth session state.
+        """Prepare regional endpoints and mutable credential state for login.
 
         Args:
             config: Parsed user config.
@@ -97,52 +97,77 @@ class MyAirAuthSession:
 
     @property
     def access_token(self) -> str | None:
-        """Return the active access token."""
+        """Expose the bearer token used for AppSync and userinfo requests."""
         return self._access_token
 
     @access_token.setter
     def access_token(self, value: str | None) -> None:
+        """Replace the bearer token after an OAuth exchange or test setup.
+
+        Args:
+            value: New access token, or ``None`` to clear cached auth state.
+        """
         self._access_token = value
 
     @property
     def id_token(self) -> str | None:
-        """Return the active id token."""
+        """Expose the ID token that contains myAir region claims."""
         return self._id_token
 
     @id_token.setter
     def id_token(self, value: str | None) -> None:
+        """Replace the ID token used to derive GraphQL country headers.
+
+        Args:
+            value: New ID token, or ``None`` when token exchange has not completed.
+        """
         self._id_token = value
 
     @property
     def state_token(self) -> str | None:
-        """Return the current state token."""
+        """Expose the Okta state token needed to continue MFA verification."""
         return self._state_token
 
     @state_token.setter
     def state_token(self, value: str | None) -> None:
+        """Store the Okta state token returned by primary authentication.
+
+        Args:
+            value: State token from Okta authn, or ``None`` to reset MFA state.
+        """
         self._state_token = value
 
     @property
     def session_token(self) -> str | None:
-        """Return the current session token."""
+        """Expose the Okta session token exchanged for OAuth tokens."""
         return self._session_token
 
     @session_token.setter
     def session_token(self, value: str | None) -> None:
+        """Store the Okta session token produced by password or MFA auth.
+
+        Args:
+            value: Session token from Okta, or ``None`` before auth succeeds.
+        """
         self._session_token = value
 
     @property
     def device_token(self) -> str | None:
-        """Return the DT cookie value."""
+        """Expose the remembered-device DT cookie used to reduce MFA prompts."""
         return self._cookie_dt
 
     @device_token.setter
     def device_token(self, value: str | None) -> None:
+        """Persist the remembered-device DT cookie from Okta responses.
+
+        Args:
+            value: DT cookie value, or ``None`` when no remembered device is available.
+        """
         self._cookie_dt = value
 
     @property
     def _cookies(self) -> dict[str, Any]:
-        """Build cookie map with DT and sid entries."""
+        """Build the auth cookie map expected by Okta requests."""
         cookies: dict[str, Any] = {}
         if self._cookie_dt:
             cookies["DT"] = self._cookie_dt
@@ -152,83 +177,127 @@ class MyAirAuthSession:
 
     @property
     def region_config(self) -> RegionConfig:
-        """Access region settings."""
+        """Expose endpoint and client IDs for the configured myAir region."""
         return self._region_config
 
     @region_config.setter
     def region_config(self, value: RegionConfig) -> None:
+        """Override regional endpoint settings for compatibility tests.
+
+        Args:
+            value: Region configuration to use for subsequent auth requests.
+        """
         self._region_config = value
 
     @property
     def email_factor_id(self) -> str:
-        """Access MFA email factor id."""
+        """Expose the Okta email factor used when triggering MFA."""
         return self._email_factor_id
 
     @email_factor_id.setter
     def email_factor_id(self, value: str) -> None:
+        """Store the MFA factor discovered from Okta authn metadata.
+
+        Args:
+            value: Email factor ID to use for MFA verification requests.
+        """
         self._email_factor_id = value
 
     @property
     def mfa_url(self) -> str:
-        """Access MFA verification URL."""
+        """Expose the Okta endpoint for the active MFA challenge."""
         return self._mfa_url
 
     @mfa_url.setter
     def mfa_url(self, value: str) -> None:
+        """Store the verification URL advertised by the current MFA challenge.
+
+        Args:
+            value: Fully qualified Okta factor verification URL.
+        """
         self._mfa_url = value
 
     @property
     def cookie_sid(self) -> str | None:
-        """Access sid cookie."""
+        """Expose the Okta session cookie captured during auth redirects."""
         return self._cookie_sid
 
     @cookie_sid.setter
     def cookie_sid(self, value: str | None) -> None:
+        """Store the Okta ``sid`` cookie for subsequent auth calls.
+
+        Args:
+            value: Session cookie value, or ``None`` when unavailable.
+        """
         self._cookie_sid = value
 
     @property
     def uses_mfa(self) -> bool:
-        """Access whether MFA is currently required."""
+        """Expose whether the current account required MFA during authn."""
         return self._uses_mfa
 
     @uses_mfa.setter
     def uses_mfa(self, value: bool) -> None:
+        """Record whether the active auth flow is waiting for MFA.
+
+        Args:
+            value: ``True`` when Okta returned ``MFA_REQUIRED``.
+        """
         self._uses_mfa = value
 
     @property
     def cookies(self) -> dict[str, Any]:
-        """Compatibility cookie map."""
+        """Expose cookies through the legacy RESTClient compatibility surface."""
         return self._cookies
 
     def set_error_checker(self, checker: _ErrorCheck) -> None:
-        """Set the error-check callback used by auth REST calls."""
+        """Inject the response validator used by RESTClient compatibility wrappers.
+
+        Args:
+            checker: Coroutine that maps ResMed response payloads to typed exceptions.
+        """
         self._resmed_error_checker = checker
 
     @property
     def country_code(self) -> str | None:
-        """Return the last resolved country code from token decoding."""
+        """Expose the cached myAir country code decoded from the ID token."""
         return self._country_code
 
     @country_code.setter
     def country_code(self, value: str | None) -> None:
+        """Cache the GraphQL country code derived from token claims.
+
+        Args:
+            value: myAir country code, or ``None`` to force token decoding later.
+        """
         self._country_code = value
 
     @property
     def json_headers(self) -> dict[str, Any]:
-        """Access request headers used for JSON payloads."""
+        """Expose default headers for Okta JSON request payloads."""
         return self._json_headers
 
     @json_headers.setter
     def json_headers(self, value: Mapping[str, Any]) -> None:
+        """Replace JSON headers while preserving an owned mutable copy.
+
+        Args:
+            value: Header mapping used for subsequent JSON requests.
+        """
         self._json_headers = dict(value)
 
     @property
     def cookie_dt(self) -> str | None:
-        """Expose DT cookie for compatibility."""
+        """Expose the remembered-device cookie under the legacy attribute name."""
         return self._cookie_dt
 
     @cookie_dt.setter
     def cookie_dt(self, value: str | None) -> None:
+        """Set the remembered-device cookie through the legacy attribute name.
+
+        Args:
+            value: DT cookie value, or ``None`` when clearing auth state.
+        """
         self._cookie_dt = value
 
     @staticmethod
@@ -238,7 +307,14 @@ class MyAirAuthSession:
         resp_dict: MutableMapping[str, Any],
         initial: bool | None = False,
     ) -> None:
-        """Public alias for shared response error handling."""
+        """Validate a ResMed response without requiring a session instance.
+
+        Args:
+            step: Human-readable auth or GraphQL step name for diagnostics.
+            response: aiohttp response object that supplied the payload.
+            resp_dict: Decoded response payload to inspect.
+            initial: Whether the failing call was part of the initial config flow.
+        """
         return await MyAirAuthSession._resmed_response_error_check(
             step, response, resp_dict, initial
         )
@@ -250,7 +326,14 @@ class MyAirAuthSession:
         resp_dict: MutableMapping[str, Any],
         initial: bool | None = False,
     ) -> None:
-        """Run configured error check implementation."""
+        """Run the active response validator for an auth request.
+
+        Args:
+            step: Human-readable auth step name for error messages.
+            response: aiohttp response object being validated.
+            resp_dict: Decoded response payload from ResMed or Okta.
+            initial: Whether the call belongs to initial setup.
+        """
         await self._resmed_error_checker(step, response, resp_dict, initial)
 
     async def connect(
@@ -263,7 +346,20 @@ class MyAirAuthSession:
         trigger_mfa: _AsyncNoArgs | None = None,
         get_access_token: _AsyncNoArgs | None = None,
     ) -> str:
-        """Run the initial auth/connect logic."""
+        """Authenticate or reuse existing credentials for a myAir session.
+
+        Args:
+            initial: Whether this is the first config-flow attempt, when MFA may be
+                triggered instead of reported as a reauth failure.
+            get_initial_dt: Optional cookie bootstrap implementation for tests.
+            is_access_token_active: Optional token introspection implementation.
+            authn_check: Optional primary Okta auth implementation.
+            trigger_mfa: Optional MFA trigger implementation.
+            get_access_token: Optional OAuth token exchange implementation.
+
+        Returns:
+            Okta auth status, such as ``SUCCESS`` or ``MFA_REQUIRED``.
+        """
         _get_initial_dt = get_initial_dt or self._get_initial_dt
         _is_access_token_active = is_access_token_active or self._is_access_token_active
         _authn_check = authn_check or self._authn_check
@@ -295,7 +391,16 @@ class MyAirAuthSession:
         verify_mfa: _AsyncAuthVerify | None = None,
         get_access_token: _AsyncNoArgs | None = None,
     ) -> str:
-        """Confirm valid MFA and obtain access token."""
+        """Complete an MFA challenge and exchange the resulting session token.
+
+        Args:
+            verification_code: Email MFA code entered by the user.
+            verify_mfa: Optional MFA verification implementation for tests.
+            get_access_token: Optional OAuth exchange implementation for tests.
+
+        Returns:
+            Okta success status after MFA verification.
+        """
         _verify_mfa = verify_mfa or self._verify_mfa
         _get_access_token = get_access_token or self._get_access_token
         status: str = await _verify_mfa(verification_code)
@@ -306,7 +411,11 @@ class MyAirAuthSession:
         return status
 
     async def is_email_verified(self) -> bool:
-        """Check if email address is marked as verified."""
+        """Check Okta userinfo for the account email-verification flag.
+
+        Returns:
+            ``True`` when Okta reports the email address has been verified.
+        """
         userinfo_url: str = self._region_config.userinfo_url
         headers: dict[str, Any] = {
             "Authorization": f"Bearer {self._access_token}",
@@ -331,7 +440,11 @@ class MyAirAuthSession:
         return False
 
     async def _extract_and_update_cookies(self, cookie_headers: list) -> None:
-        """Parse DT and sid cookies from Set-Cookie values."""
+        """Parse remembered-device and session cookies from response headers.
+
+        Args:
+            cookie_headers: Raw ``Set-Cookie`` header values from Okta responses.
+        """
         cookies: dict[str, Any] = {}
         for header in cookie_headers:
             cookie = SimpleCookie(header)
@@ -361,11 +474,19 @@ class MyAirAuthSession:
         )
 
     async def extract_and_update_cookies(self, cookie_headers: list) -> None:
-        """Public compatibility delegate for cookie extraction."""
+        """Update auth cookies through the legacy RESTClient helper.
+
+        Args:
+            cookie_headers: Raw ``Set-Cookie`` header values from Okta responses.
+        """
         await self._extract_and_update_cookies(cookie_headers)
 
     async def _get_initial_dt(self, extract_cookies: _CookieUpdate | None = None) -> None:
-        """Fetch initial authorize response to capture DT cookie."""
+        """Prime the auth session with the remembered-device cookie.
+
+        Args:
+            extract_cookies: Optional cookie extractor used by compatibility tests.
+        """
         _extract_cookies = extract_cookies or self._extract_and_update_cookies
         initial_dt_url: str = self._region_config.authorize_url
         _LOGGER.debug("[get_initial_dt] initial_dt_url: %s", initial_dt_url)
@@ -383,11 +504,19 @@ class MyAirAuthSession:
         await _extract_cookies(initial_dt_res.headers.getall("set-cookie", []))
 
     async def get_initial_dt(self, extract_cookies: _CookieUpdate | None = None) -> None:
-        """Public compatibility delegate for initial DT retrieval."""
+        """Prime the remembered-device cookie through the public helper.
+
+        Args:
+            extract_cookies: Optional cookie extractor used by compatibility tests.
+        """
         await self._get_initial_dt(extract_cookies)
 
     async def _is_access_token_active(self) -> bool:
-        """Check whether current access token still reports active."""
+        """Ask Okta introspection whether the cached access token is reusable.
+
+        Returns:
+            ``True`` when Okta marks the cached access token active.
+        """
         introspect_url: str = self._region_config.introspect_url
         headers: dict[str, Any] = {
             "Accept": "application/json",
@@ -420,7 +549,11 @@ class MyAirAuthSession:
         return False
 
     async def is_access_token_active(self) -> bool:
-        """Public compatibility delegate for access-token activity check."""
+        """Check cached access-token validity through the public helper.
+
+        Returns:
+            ``True`` when the access token can be reused.
+        """
         return await self._is_access_token_active()
 
     @staticmethod
@@ -430,7 +563,20 @@ class MyAirAuthSession:
         resp_dict: MutableMapping[str, Any],
         initial: bool | None = False,
     ) -> None:
-        """Raise typed exceptions for ResMed error responses."""
+        """Map ResMed and Okta error payloads to integration exceptions.
+
+        Args:
+            step: Human-readable auth or GraphQL step name for diagnostics.
+            response: aiohttp response object associated with the payload.
+            resp_dict: Decoded response payload to inspect.
+            initial: Whether a GraphQL unauthorized response occurred during setup.
+
+        Raises:
+            AuthenticationError: When credentials or auth state are rejected.
+            IncompleteAccountError: When myAir reports account setup is incomplete.
+            ParsingError: When a non-initial GraphQL request becomes unauthorized.
+            HttpProcessingError: When a structured error exists but has no typed mapping.
+        """
         if "errors" in resp_dict:
             try:
                 if "errorInfo" in resp_dict["errors"][0]:
@@ -466,7 +612,14 @@ class MyAirAuthSession:
             )
 
     async def _authn_check(self) -> str:
-        """Validate primary username/password credentials with Okta."""
+        """Submit username and password to Okta and capture next auth state.
+
+        Returns:
+            Okta status indicating success or that MFA is required.
+
+        Raises:
+            AuthenticationError: When the authn payload is missing required state.
+        """
         authn_url: str = self._region_config.authn_url
         json_query: dict[str, Any] = {
             "username": self._config.username,
@@ -517,11 +670,15 @@ class MyAirAuthSession:
         return status
 
     async def authn_check(self) -> str:
-        """Public compatibility delegate for authn check."""
+        """Run primary Okta auth through the public helper.
+
+        Returns:
+            Okta status indicating success or MFA requirement.
+        """
         return await self._authn_check()
 
     async def _trigger_mfa(self) -> None:
-        """Trigger the MFA email flow."""
+        """Ask Okta to send the email MFA challenge for the current state token."""
         json_query: dict[str, Any] = {"passCode": "", "stateToken": self._state_token}
         _LOGGER.debug("[trigger_mfa] mfa_url: %s", self._mfa_url)
         _LOGGER.debug("[trigger_mfa] headers: %s", redact_dict(self._json_headers))
@@ -543,11 +700,21 @@ class MyAirAuthSession:
         _LOGGER.info("Triggered MFA Email")
 
     async def trigger_mfa(self) -> None:
-        """Public compatibility delegate for MFA trigger."""
+        """Send the email MFA challenge through the public helper."""
         await self._trigger_mfa()
 
     async def _verify_mfa(self, verification_code: str) -> str:
-        """Verify MFA code and update session token."""
+        """Submit an email MFA code and store the returned session token.
+
+        Args:
+            verification_code: MFA code supplied by the user.
+
+        Returns:
+            Okta status after code verification.
+
+        Raises:
+            AuthenticationError: When Okta omits expected status or session data.
+        """
         json_query: dict[str, Any] = {
             "passCode": verification_code,
             "stateToken": self._state_token,
@@ -583,14 +750,28 @@ class MyAirAuthSession:
         return status
 
     async def verify_mfa(self, verification_code: str) -> str:
-        """Public compatibility delegate for MFA verification."""
+        """Verify an email MFA code through the public helper.
+
+        Args:
+            verification_code: MFA code supplied by the user.
+
+        Returns:
+            Okta status after code verification.
+        """
         return await self._verify_mfa(verification_code)
 
     async def _get_access_token(
         self,
         extract_cookies: _CookieUpdate | None = None,
     ) -> None:
-        """Exchange session token for an access and id token."""
+        """Exchange the Okta session token for OAuth access and ID tokens.
+
+        Args:
+            extract_cookies: Optional cookie extractor used by compatibility tests.
+
+        Raises:
+            ParsingError: When Okta redirects or token payloads omit required fields.
+        """
         _extract_cookies = extract_cookies or self._extract_and_update_cookies
         # myAir uses Authorization Code with PKCE, so we generate our verifier here
         code_verifier: str = base64.urlsafe_b64encode(os.urandom(40)).decode("utf-8")
@@ -693,5 +874,9 @@ class MyAirAuthSession:
                 self._access_token = access_token
 
     async def get_access_token(self, extract_cookies: _CookieUpdate | None = None) -> None:
-        """Public compatibility delegate for token exchange."""
+        """Run OAuth token exchange through the public helper.
+
+        Args:
+            extract_cookies: Optional cookie extractor used by compatibility tests.
+        """
         await self._get_access_token(extract_cookies)

--- a/custom_components/resmed_myair/client/const.py
+++ b/custom_components/resmed_myair/client/const.py
@@ -1,4 +1,4 @@
-"""Constants for ResMed myAir Client."""
+"""Auth status, region, and redaction constants shared by the myAir client."""
 
 AUTHN_SUCCESS = "SUCCESS"
 AUTH_NEEDS_MFA = "MFA_REQUIRED"

--- a/custom_components/resmed_myair/client/graphql.py
+++ b/custom_components/resmed_myair/client/graphql.py
@@ -15,12 +15,12 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 class MyAirGraphQLClient:
-    """Execute ResMed AppSync GraphQL operations."""
+    """Execute authenticated ResMed AppSync operations for myAir data."""
 
     def __init__(
         self, session: ClientSession, auth: MyAirAuthSession, region_config: RegionConfig
     ) -> None:
-        """Initialize the GraphQL client.
+        """Bind GraphQL requests to the shared session and auth state.
 
         Args:
             session: Shared aiohttp client session.
@@ -33,7 +33,7 @@ class MyAirGraphQLClient:
         self._country_code: str | None = None
 
     async def query(self, operation_name: str, query: str, initial: bool = False) -> dict[str, Any]:
-        """Run a GraphQL query.
+        """Post a myAir GraphQL operation and validate ResMed errors.
 
         Args:
             operation_name: GraphQL operation name.
@@ -41,7 +41,7 @@ class MyAirGraphQLClient:
             initial: Whether this query is part of initial config flow.
 
         Returns:
-            Decoded JSON response.
+            Decoded GraphQL response payload.
         """
         headers = self._headers()
         json_query: dict[str, Any] = {
@@ -68,7 +68,14 @@ class MyAirGraphQLClient:
         return dict(records_dict)
 
     def _headers(self) -> dict[str, str]:
-        """Return headers required by ResMed AppSync."""
+        """Build AppSync headers from regional constants and token claims.
+
+        Returns:
+            Headers accepted by ResMed's myAir GraphQL endpoint.
+
+        Raises:
+            ParsingError: When no country code can be derived for AppSync.
+        """
         country_code: str | None = self._country_code or self._country_code_from_id_token()
         if not country_code:
             raise ParsingError("country_code not defined and id_token not present to identify it")
@@ -88,7 +95,14 @@ class MyAirGraphQLClient:
         }
 
     def _country_code_from_id_token(self) -> str | None:
-        """Derive the myAir country code from the ID token."""
+        """Decode the unsigned ID token claim used by ResMed's country header.
+
+        Returns:
+            myAir country code, or ``None`` when no ID token is available yet.
+
+        Raises:
+            ParsingError: When the ID token cannot be decoded or lacks the claim.
+        """
         if not self._auth.id_token:
             return None
         try:

--- a/custom_components/resmed_myair/client/helpers.py
+++ b/custom_components/resmed_myair/client/helpers.py
@@ -1,4 +1,4 @@
-"""Helper functions for ResMed myAir Client."""
+"""Compatibility exports for client code that imports redaction helpers here."""
 
 from custom_components.resmed_myair.redaction import REDACTED, redact_dict
 

--- a/custom_components/resmed_myair/client/myair_client.py
+++ b/custom_components/resmed_myair/client/myair_client.py
@@ -1,4 +1,4 @@
-"""Base classes for myAir Client."""
+"""Client contracts and exceptions shared by myAir transport implementations."""
 
 from abc import ABC, abstractmethod
 from typing import NamedTuple
@@ -7,22 +7,19 @@ from custom_components.resmed_myair.models import MyAirDevice, MyAirSleepRecord
 
 
 class AuthenticationError(Exception):
-    """Error thrown when Authentication fails.
-
-    This could mean the username/password or domain is incorrect or the MFA was incorrect.
-    """
+    """Authentication failure that should surface as setup or reauth repair."""
 
 
 class IncompleteAccountError(Exception):
-    """Error thrown when ResMed reports that the account is not fully setup."""
+    """myAir account state prevents API access until the user completes setup."""
 
 
 class ParsingError(Exception):
-    """Error is thrown when the expected data is not found in the result."""
+    """Remote payload shape does not match the fields this integration requires."""
 
 
 class MyAirConfig(NamedTuple):
-    """Config for logging into myAir."""
+    """Credentials and regional context needed to authenticate with myAir."""
 
     username: str
     password: str
@@ -31,16 +28,34 @@ class MyAirConfig(NamedTuple):
 
 
 class MyAirClient(ABC):
-    """Basic myAir Client Class."""
+    """Abstract async contract consumed by the Home Assistant coordinator."""
 
     @abstractmethod
     async def connect(self) -> str:
-        """Connect to ResMed myAir."""
+        """Authenticate or validate cached credentials before data fetches.
+
+        Returns:
+            Provider-specific auth status string.
+        """
 
     @abstractmethod
     async def get_user_device_data(self, initial: bool = False) -> MyAirDevice:
-        """Get user device data from ResMed servers."""
+        """Fetch the account's assigned flow-generator device.
+
+        Args:
+            initial: Whether the fetch is part of initial setup rather than polling.
+
+        Returns:
+            Typed device metadata used for entity identity and device info.
+        """
 
     @abstractmethod
     async def get_sleep_records(self, initial: bool = False) -> list[MyAirSleepRecord]:
-        """Get sleep records from ResMed servers."""
+        """Fetch recent nightly therapy records for sensor state.
+
+        Args:
+            initial: Whether the fetch is part of initial setup rather than polling.
+
+        Returns:
+            Typed sleep records ordered as returned by the transport implementation.
+        """

--- a/custom_components/resmed_myair/client/regions.py
+++ b/custom_components/resmed_myair/client/regions.py
@@ -7,7 +7,7 @@ from .const import REGION_NA
 
 @dataclass(frozen=True, slots=True)
 class RegionConfig:
-    """Endpoint and client settings for a ResMed myAir region."""
+    """Static endpoints and client identifiers for one myAir region."""
 
     product: str
     okta_url: str
@@ -20,37 +20,37 @@ class RegionConfig:
 
     @property
     def authn_url(self) -> str:
-        """Return the Okta authn URL."""
+        """Build the Okta primary-authentication endpoint URL."""
         return f"https://{self.okta_url}/api/v1/authn"
 
     @property
     def authorize_url(self) -> str:
-        """Return the Okta authorize URL."""
+        """Build the Okta authorization-code endpoint URL."""
         return f"https://{self.okta_url}/oauth2/{self.auth_server_id}/v1/authorize"
 
     @property
     def token_url(self) -> str:
-        """Return the Okta token URL."""
+        """Build the Okta token-exchange endpoint URL."""
         return f"https://{self.okta_url}/oauth2/{self.auth_server_id}/v1/token"
 
     @property
     def introspect_url(self) -> str:
-        """Return the Okta token introspection URL."""
+        """Build the Okta access-token introspection endpoint URL."""
         return f"https://{self.okta_url}/oauth2/{self.auth_server_id}/v1/introspect"
 
     @property
     def userinfo_url(self) -> str:
-        """Return the Okta userinfo URL."""
+        """Build the Okta userinfo endpoint URL used for account checks."""
         return f"https://{self.okta_url}/oauth2/{self.auth_server_id}/v1/userinfo"
 
     def mfa_url(self, email_factor_id: str | None = None) -> str:
-        """Return the Okta MFA verification URL.
+        """Build the email-factor MFA endpoint for an auth challenge.
 
         Args:
             email_factor_id: Optional factor ID discovered from authn.
 
         Returns:
-            The MFA verification URL.
+            Fully qualified Okta MFA verification URL.
         """
         factor_id = email_factor_id or self.email_factor_id
         return (
@@ -102,12 +102,12 @@ EU_CONFIG: RegionConfig = RegionConfig(
 
 
 def get_region_config(region: str) -> RegionConfig:
-    """Return the region configuration matching the configured region.
+    """Resolve a user-selected region code to endpoint settings.
 
     Args:
         region: Region code configured by the user.
 
     Returns:
-        The region config object for the requested region.
+        North America settings for ``REGION_NA``; Europe settings otherwise.
     """
     return NA_CONFIG if region == REGION_NA else EU_CONFIG

--- a/custom_components/resmed_myair/client/rest_client.py
+++ b/custom_components/resmed_myair/client/rest_client.py
@@ -51,7 +51,7 @@ class RESTClient(MyAirClient):
 
     @property
     def _country_code(self) -> str | None:
-        """Expose the GraphQL country-code cache for legacy tests."""
+        """Proxy the AppSync country-code cache owned by the GraphQL helper."""
         return self._graphql._country_code  # noqa: SLF001
 
     @_country_code.setter
@@ -70,17 +70,17 @@ class RESTClient(MyAirClient):
 
     @property
     def _cookies(self) -> dict[str, Any]:
-        """Expose Okta cookies through the legacy private RESTClient attribute."""
+        """Proxy the Okta cookie jar assembled by the auth session."""
         return self._auth.cookies
 
     @property
     def _json_headers(self) -> dict[str, Any]:
-        """Expose JSON auth headers through the legacy private attribute."""
+        """Proxy JSON request headers used by Okta auth endpoints."""
         return self._auth.json_headers
 
     @_json_headers.setter
     def _json_headers(self, value: Mapping[str, Any]) -> None:
-        """Replace JSON auth headers through the legacy private attribute.
+        """Forward JSON header overrides into the auth session.
 
         Args:
             value: Header mapping used for subsequent Okta JSON requests.
@@ -89,12 +89,12 @@ class RESTClient(MyAirClient):
 
     @property
     def _region_config(self) -> RegionConfig:
-        """Expose regional endpoint settings through the legacy attribute."""
+        """Proxy regional endpoint settings owned by the auth session."""
         return self._auth.region_config
 
     @_region_config.setter
     def _region_config(self, value: RegionConfig) -> None:
-        """Replace regional endpoint settings through the legacy attribute.
+        """Forward regional endpoint overrides into the auth session.
 
         Args:
             value: Region configuration used by future auth calls.
@@ -103,12 +103,12 @@ class RESTClient(MyAirClient):
 
     @property
     def _email_factor_id(self) -> str:
-        """Expose the active Okta email factor ID through the legacy attribute."""
+        """Proxy the Okta email factor selected for MFA verification."""
         return self._auth.email_factor_id
 
     @_email_factor_id.setter
     def _email_factor_id(self, value: str) -> None:
-        """Store the active Okta email factor ID through the legacy attribute.
+        """Forward MFA factor updates into the auth session.
 
         Args:
             value: MFA email factor ID to use for verification.
@@ -117,12 +117,12 @@ class RESTClient(MyAirClient):
 
     @property
     def _mfa_url(self) -> str:
-        """Expose the active Okta MFA verification URL through the legacy attribute."""
+        """Proxy the challenge-specific Okta MFA verification URL."""
         return self._auth.mfa_url
 
     @_mfa_url.setter
     def _mfa_url(self, value: str) -> None:
-        """Store the active Okta MFA verification URL through the legacy attribute.
+        """Forward MFA verification endpoint updates into the auth session.
 
         Args:
             value: Fully qualified Okta MFA verification URL.
@@ -131,12 +131,12 @@ class RESTClient(MyAirClient):
 
     @property
     def _cookie_dt(self) -> str | None:
-        """Expose the remembered-device cookie through the legacy attribute."""
+        """Proxy the Okta remembered-device cookie used to reduce MFA prompts."""
         return self._auth.device_token
 
     @_cookie_dt.setter
     def _cookie_dt(self, value: str | None) -> None:
-        """Store the remembered-device cookie through the legacy attribute.
+        """Forward remembered-device cookie updates into the auth session.
 
         Args:
             value: DT cookie value, or ``None`` to clear it.
@@ -145,12 +145,12 @@ class RESTClient(MyAirClient):
 
     @property
     def _cookie_sid(self) -> str | None:
-        """Expose the Okta session cookie through the legacy attribute."""
+        """Proxy the Okta browser-session cookie captured during auth."""
         return self._auth.cookie_sid
 
     @_cookie_sid.setter
     def _cookie_sid(self, value: str | None) -> None:
-        """Store the Okta session cookie through the legacy attribute.
+        """Forward Okta session-cookie updates into the auth session.
 
         Args:
             value: ``sid`` cookie value, or ``None`` to clear it.
@@ -159,12 +159,12 @@ class RESTClient(MyAirClient):
 
     @property
     def _uses_mfa(self) -> bool:
-        """Expose whether Okta required MFA through the legacy attribute."""
+        """Proxy whether the current auth flow is waiting on MFA."""
         return self._auth.uses_mfa
 
     @_uses_mfa.setter
     def _uses_mfa(self, value: bool) -> None:
-        """Store whether Okta required MFA through the legacy attribute.
+        """Forward MFA-required state updates into the auth session.
 
         Args:
             value: ``True`` when the current auth flow is waiting for MFA.
@@ -173,12 +173,12 @@ class RESTClient(MyAirClient):
 
     @property
     def _access_token(self) -> str | None:
-        """Expose the OAuth bearer token through the legacy attribute."""
+        """Proxy the OAuth bearer token consumed by GraphQL and userinfo calls."""
         return self._auth.access_token
 
     @_access_token.setter
     def _access_token(self, value: str | None) -> None:
-        """Store the OAuth bearer token through the legacy attribute.
+        """Forward OAuth bearer-token updates into the auth session.
 
         Args:
             value: Access token, or ``None`` before auth succeeds.
@@ -187,12 +187,12 @@ class RESTClient(MyAirClient):
 
     @property
     def _id_token(self) -> str | None:
-        """Expose the OAuth ID token through the legacy attribute."""
+        """Proxy the OAuth ID token used to derive myAir country headers."""
         return self._auth.id_token
 
     @_id_token.setter
     def _id_token(self, value: str | None) -> None:
-        """Store the OAuth ID token through the legacy attribute.
+        """Forward OAuth ID-token updates into the auth session.
 
         Args:
             value: ID token, or ``None`` before token exchange succeeds.
@@ -201,12 +201,12 @@ class RESTClient(MyAirClient):
 
     @property
     def _state_token(self) -> str | None:
-        """Expose the Okta MFA state token through the legacy attribute."""
+        """Proxy the Okta state token that ties MFA calls to authn."""
         return self._auth.state_token
 
     @_state_token.setter
     def _state_token(self, value: str | None) -> None:
-        """Store the Okta MFA state token through the legacy attribute.
+        """Forward Okta state-token updates into the auth session.
 
         Args:
             value: State token, or ``None`` when no MFA flow is active.
@@ -215,12 +215,12 @@ class RESTClient(MyAirClient):
 
     @property
     def _session_token(self) -> str | None:
-        """Expose the Okta session token through the legacy attribute."""
+        """Proxy the Okta session token exchanged for OAuth credentials."""
         return self._auth.session_token
 
     @_session_token.setter
     def _session_token(self, value: str | None) -> None:
-        """Store the Okta session token through the legacy attribute.
+        """Forward Okta session-token updates into the auth session.
 
         Args:
             value: Session token, or ``None`` before auth succeeds.

--- a/custom_components/resmed_myair/client/rest_client.py
+++ b/custom_components/resmed_myair/client/rest_client.py
@@ -30,10 +30,15 @@ AUTHN_SUCCESS: str = _AUTHN_SUCCESS
 
 
 class RESTClient(MyAirClient):
-    """myAir uses oauth on Okta and AWS AppSync GraphQL."""
+    """Coordinate myAir authentication and AppSync GraphQL data access."""
 
     def __init__(self, config: MyAirConfig, session: ClientSession) -> None:
-        """Initialize REST Client."""
+        """Create auth and GraphQL helpers around a shared aiohttp session.
+
+        Args:
+            config: User credentials, region, and optional remembered-device token.
+            session: Home Assistant-managed aiohttp session.
+        """
         _LOGGER.debug("[RESTClient init] config: %s", redact_dict(config._asdict()))
         self._config: MyAirConfig = config
         self._session: ClientSession = session
@@ -46,128 +51,196 @@ class RESTClient(MyAirClient):
 
     @property
     def _country_code(self) -> str | None:
-        """Compatibility alias for GraphQL country code cache."""
+        """Expose the GraphQL country-code cache for legacy tests."""
         return self._graphql._country_code  # noqa: SLF001
 
     @_country_code.setter
     def _country_code(self, value: str | None) -> None:
+        """Set the GraphQL country-code cache for compatibility.
+
+        Args:
+            value: myAir country code, or ``None`` to force token decoding later.
+        """
         self._graphql._country_code = value  # noqa: SLF001
 
     @property
     def device_token(self) -> str | None:
-        """Return the device token."""
+        """Expose the remembered-device token that should be saved in config entries."""
         return self._auth.device_token
 
     @property
     def _cookies(self) -> dict[str, Any]:
-        """Compatibility cookie mapping."""
+        """Expose Okta cookies through the legacy private RESTClient attribute."""
         return self._auth.cookies
 
     @property
     def _json_headers(self) -> dict[str, Any]:
-        """Compatibility JSON header mapping."""
+        """Expose JSON auth headers through the legacy private attribute."""
         return self._auth.json_headers
 
     @_json_headers.setter
     def _json_headers(self, value: Mapping[str, Any]) -> None:
+        """Replace JSON auth headers through the legacy private attribute.
+
+        Args:
+            value: Header mapping used for subsequent Okta JSON requests.
+        """
         self._auth.json_headers = value
 
     @property
     def _region_config(self) -> RegionConfig:
-        """Return region config from auth session."""
+        """Expose regional endpoint settings through the legacy attribute."""
         return self._auth.region_config
 
     @_region_config.setter
     def _region_config(self, value: RegionConfig) -> None:
+        """Replace regional endpoint settings through the legacy attribute.
+
+        Args:
+            value: Region configuration used by future auth calls.
+        """
         self._auth.region_config = value
 
     @property
     def _email_factor_id(self) -> str:
-        """Return MFA factor ID from auth session."""
+        """Expose the active Okta email factor ID through the legacy attribute."""
         return self._auth.email_factor_id
 
     @_email_factor_id.setter
     def _email_factor_id(self, value: str) -> None:
+        """Store the active Okta email factor ID through the legacy attribute.
+
+        Args:
+            value: MFA email factor ID to use for verification.
+        """
         self._auth.email_factor_id = value
 
     @property
     def _mfa_url(self) -> str:
-        """Return MFA verification URL from auth session."""
+        """Expose the active Okta MFA verification URL through the legacy attribute."""
         return self._auth.mfa_url
 
     @_mfa_url.setter
     def _mfa_url(self, value: str) -> None:
+        """Store the active Okta MFA verification URL through the legacy attribute.
+
+        Args:
+            value: Fully qualified Okta MFA verification URL.
+        """
         self._auth.mfa_url = value
 
     @property
     def _cookie_dt(self) -> str | None:
-        """Return DT cookie from auth session."""
+        """Expose the remembered-device cookie through the legacy attribute."""
         return self._auth.device_token
 
     @_cookie_dt.setter
     def _cookie_dt(self, value: str | None) -> None:
+        """Store the remembered-device cookie through the legacy attribute.
+
+        Args:
+            value: DT cookie value, or ``None`` to clear it.
+        """
         self._auth.device_token = value
 
     @property
     def _cookie_sid(self) -> str | None:
-        """Return sid cookie from auth session."""
+        """Expose the Okta session cookie through the legacy attribute."""
         return self._auth.cookie_sid
 
     @_cookie_sid.setter
     def _cookie_sid(self, value: str | None) -> None:
+        """Store the Okta session cookie through the legacy attribute.
+
+        Args:
+            value: ``sid`` cookie value, or ``None`` to clear it.
+        """
         self._auth.cookie_sid = value
 
     @property
     def _uses_mfa(self) -> bool:
-        """Return MFA-needed marker from auth session."""
+        """Expose whether Okta required MFA through the legacy attribute."""
         return self._auth.uses_mfa
 
     @_uses_mfa.setter
     def _uses_mfa(self, value: bool) -> None:
+        """Store whether Okta required MFA through the legacy attribute.
+
+        Args:
+            value: ``True`` when the current auth flow is waiting for MFA.
+        """
         self._auth.uses_mfa = value
 
     @property
     def _access_token(self) -> str | None:
-        """Compatibility alias for access token."""
+        """Expose the OAuth bearer token through the legacy attribute."""
         return self._auth.access_token
 
     @_access_token.setter
     def _access_token(self, value: str | None) -> None:
+        """Store the OAuth bearer token through the legacy attribute.
+
+        Args:
+            value: Access token, or ``None`` before auth succeeds.
+        """
         self._auth.access_token = value
 
     @property
     def _id_token(self) -> str | None:
-        """Compatibility alias for ID token."""
+        """Expose the OAuth ID token through the legacy attribute."""
         return self._auth.id_token
 
     @_id_token.setter
     def _id_token(self, value: str | None) -> None:
+        """Store the OAuth ID token through the legacy attribute.
+
+        Args:
+            value: ID token, or ``None`` before token exchange succeeds.
+        """
         self._auth.id_token = value
 
     @property
     def _state_token(self) -> str | None:
-        """Compatibility alias for state token."""
+        """Expose the Okta MFA state token through the legacy attribute."""
         return self._auth.state_token
 
     @_state_token.setter
     def _state_token(self, value: str | None) -> None:
+        """Store the Okta MFA state token through the legacy attribute.
+
+        Args:
+            value: State token, or ``None`` when no MFA flow is active.
+        """
         self._auth.state_token = value
 
     @property
     def _session_token(self) -> str | None:
-        """Compatibility alias for session token."""
+        """Expose the Okta session token through the legacy attribute."""
         return self._auth.session_token
 
     @_session_token.setter
     def _session_token(self, value: str | None) -> None:
+        """Store the Okta session token through the legacy attribute.
+
+        Args:
+            value: Session token, or ``None`` before auth succeeds.
+        """
         self._auth.session_token = value
 
     def _refresh_auth_error_checker(self) -> None:
-        """Keep auth error checks aligned with the public wrapper."""
+        """Route auth helper validation through RESTClient's compatibility wrapper."""
         self._auth.set_error_checker(self._resmed_response_error_check)
 
     async def connect(self, initial: bool | None = False) -> str:
-        """Check authn and connect to ResMed servers."""
+        """Authenticate with myAir or reuse an active OAuth token.
+
+        Args:
+            initial: Whether the call is part of config setup, where MFA can be
+                triggered and surfaced to the user.
+
+        Returns:
+            Okta authentication status.
+        """
         self._refresh_auth_error_checker()
         return await self._auth.connect(
             initial=initial,
@@ -179,7 +252,14 @@ class RESTClient(MyAirClient):
         )
 
     async def verify_mfa_and_get_access_token(self, verification_code: str) -> str:
-        """Confirm valid MFA and obtain access token."""
+        """Complete an MFA challenge and cache OAuth tokens.
+
+        Args:
+            verification_code: Email MFA code supplied by the user.
+
+        Returns:
+            Okta authentication status after MFA verification.
+        """
         self._refresh_auth_error_checker()
         return await self._auth.verify_mfa_and_get_access_token(
             verification_code,
@@ -188,7 +268,7 @@ class RESTClient(MyAirClient):
         )
 
     async def is_email_verified(self) -> bool:
-        """Check if email address is verified."""
+        """Return whether Okta userinfo reports a verified email address."""
         self._refresh_auth_error_checker()
         return await self._auth.is_email_verified()
 
@@ -199,54 +279,96 @@ class RESTClient(MyAirClient):
         resp_dict: MutableMapping[str, Any],
         initial: bool | None = False,
     ) -> None:
-        """Compatibility wrapper over MyAirAuthSession error handling."""
+        """Validate ResMed responses through the legacy static helper.
+
+        Args:
+            step: Human-readable auth or GraphQL step name for diagnostics.
+            response: aiohttp response object associated with the payload.
+            resp_dict: Decoded response payload to inspect.
+            initial: Whether the request belongs to initial config setup.
+        """
         return await MyAirAuthSession.resmed_response_error_check(
             step, response, resp_dict, initial
         )
 
     async def _extract_and_update_cookies(self, cookie_headers: list) -> None:
-        """Compatibility wrapper for auth session cookie extraction."""
+        """Update remembered-device and session cookies from Okta headers.
+
+        Args:
+            cookie_headers: Raw ``Set-Cookie`` header values from Okta responses.
+        """
         self._refresh_auth_error_checker()
         await self._auth.extract_and_update_cookies(cookie_headers)
 
     async def _get_initial_dt(self) -> None:
-        """Compatibility wrapper for auth initial DT retrieval."""
+        """Bootstrap the remembered-device cookie before primary authentication."""
         self._refresh_auth_error_checker()
         await self._auth.get_initial_dt(self._extract_and_update_cookies)
 
     async def _is_access_token_active(self) -> bool:
-        """Compatibility wrapper for access token status check."""
+        """Check if the cached OAuth token can be reused.
+
+        Returns:
+            ``True`` when Okta introspection marks the token active.
+        """
         self._refresh_auth_error_checker()
         return await self._auth.is_access_token_active()
 
     async def _authn_check(self) -> str:
-        """Compatibility wrapper for authn check."""
+        """Run primary Okta username/password authentication.
+
+        Returns:
+            Okta status indicating success or an MFA requirement.
+        """
         self._refresh_auth_error_checker()
         return await self._auth.authn_check()
 
     async def _trigger_mfa(self) -> None:
-        """Compatibility wrapper for MFA trigger."""
+        """Send an email MFA challenge for the active Okta state token."""
         self._refresh_auth_error_checker()
         return await self._auth.trigger_mfa()
 
     async def _verify_mfa(self, verification_code: str) -> str:
-        """Compatibility wrapper for MFA verification."""
+        """Submit an email MFA code and capture the resulting session token.
+
+        Args:
+            verification_code: MFA code supplied by the user.
+
+        Returns:
+            Okta status after verification.
+        """
         self._refresh_auth_error_checker()
         return await self._auth.verify_mfa(verification_code)
 
     async def _get_access_token(self) -> None:
-        """Compatibility wrapper for token exchange."""
+        """Exchange the Okta session token for OAuth access and ID tokens."""
         self._refresh_auth_error_checker()
         await self._auth.get_access_token(self._extract_and_update_cookies)
 
     async def _gql_query(
         self, operation_name: str, query: str, initial: bool | None = False
     ) -> dict[str, Any]:
-        """Run a GraphQL query through the transport client."""
+        """Execute a myAir AppSync operation with the current auth state.
+
+        Args:
+            operation_name: GraphQL operation name sent to AppSync.
+            query: GraphQL document to execute.
+            initial: Whether the query is part of config setup.
+
+        Returns:
+            Decoded GraphQL response payload.
+        """
         return await self._graphql.query(operation_name, query, initial=bool(initial))
 
     async def get_sleep_records(self, initial: bool = False) -> list[MyAirSleepRecord]:
-        """Get sleep records from ResMed servers."""
+        """Fetch and normalize the recent nightly sleep records.
+
+        Args:
+            initial: Whether this fetch is part of config setup.
+
+        Returns:
+            Typed records returned by myAir for the last 30 days.
+        """
         today_date: datetime.date = datetime.datetime.now(datetime.UTC).astimezone().date()
         today: str = today_date.isoformat()
         one_month_ago: str = (today_date - datetime.timedelta(days=30)).isoformat()
@@ -310,7 +432,14 @@ class RESTClient(MyAirClient):
         return typed_records
 
     async def get_user_device_data(self, initial: bool = False) -> MyAirDevice:
-        """Get user device data from ResMed servers."""
+        """Fetch and normalize the account's assigned flow-generator device.
+
+        Args:
+            initial: Whether this fetch is part of config setup.
+
+        Returns:
+            Typed device data enriched with the first mask code when available.
+        """
         query: str = """
         query getPatientWrapper {
             getPatientWrapper {

--- a/custom_components/resmed_myair/config_flow.py
+++ b/custom_components/resmed_myair/config_flow.py
@@ -54,7 +54,18 @@ async def get_device(
     region: str,
     device_token: str | None = None,
 ) -> tuple[str, MyAirDevice | None, RESTClient]:
-    """Login and get user device data from ResMed servers."""
+    """Authenticate with myAir and fetch device data when login is complete.
+
+    Args:
+        hass: Home Assistant instance used to create the aiohttp session.
+        username: myAir account username.
+        password: myAir account password.
+        region: myAir region code selected by the user.
+        device_token: Optional remembered-device token from a previous setup.
+
+    Returns:
+        Auth status, optional device data, and the client carrying auth state.
+    """
     _LOGGER.debug("[get_device] Starting")
     config = MyAirConfig(
         username=username, password=password, region=region, device_token=device_token
@@ -71,7 +82,15 @@ async def get_device(
 
 
 async def get_mfa_device(client: RESTClient, verification_code: str) -> tuple[str, MyAirDevice]:
-    """Get access token and user device data."""
+    """Complete MFA and fetch device data with the authenticated client.
+
+    Args:
+        client: REST client already holding an active MFA challenge.
+        verification_code: Email MFA code entered by the user.
+
+    Returns:
+        Auth success status and the account's assigned device.
+    """
     _LOGGER.debug("[get_mfa_device] Starting")
     status: str = await client.verify_mfa_and_get_access_token(verification_code)
     device = await client.get_user_device_data(initial=True)
@@ -79,13 +98,13 @@ async def get_mfa_device(client: RESTClient, verification_code: str) -> tuple[st
 
 
 class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Config flow for resmed_myair."""
+    """Drive initial setup, MFA, and reauth for a myAir account."""
 
     # For future migration support
     VERSION = 2
 
     def __init__(self) -> None:
-        """Initialize flow."""
+        """Initialize per-flow client and form data state."""
         self._client: RESTClient | None = None
         self._entry: ConfigEntry
         self._data: MutableMapping[str, Any] = {}
@@ -94,7 +113,14 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
         self,
         device_token: str | None = None,
     ) -> tuple[str, MyAirDevice | None]:
-        """Login with stored flow data and fetch the user device."""
+        """Attempt login using collected form data.
+
+        Args:
+            device_token: Optional remembered-device token to reuse during reauth.
+
+        Returns:
+            Auth status and device data when auth completed without MFA.
+        """
         status, device, self._client = await get_device(
             self.hass,
             self._data[CONF_USER_NAME],
@@ -105,7 +131,14 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
         return status, device
 
     async def _async_verify_mfa_and_get_device(self) -> tuple[str, MyAirDevice]:
-        """Verify MFA with stored flow data and fetch the user device."""
+        """Verify the submitted MFA code using the active REST client.
+
+        Returns:
+            Auth status and device data after MFA succeeds.
+
+        Raises:
+            AuthenticationError: When the flow reaches MFA without an initialized client.
+        """
         if not isinstance(self._client, RESTClient):
             raise AuthenticationError("MFA client is not initialized")
         return await get_mfa_device(
@@ -114,12 +147,19 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     def _store_device_token(self) -> None:
-        """Store the current client device token in flow data."""
+        """Persist the latest remembered-device token into the config payload."""
         if self._client:
             self._data.update({CONF_DEVICE_TOKEN: self._client.device_token})
 
     def _entry_title(self, device: MyAirDevice) -> str:
-        """Return the config entry title for a device."""
+        """Build a stable Home Assistant entry title from device metadata.
+
+        Args:
+            device: Typed myAir device returned by the API.
+
+        Returns:
+            Manufacturer and localized name joined for display.
+        """
         manufacturer = device.manufacturer or "ResMed"
         name = device.name or "myAir"
         return f"{manufacturer}-{name}"
@@ -127,7 +167,15 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
     async def _async_abort_incomplete_account(
         self, step: str, error: IncompleteAccountError
     ) -> ConfigFlowResult:
-        """Abort incomplete-account flows with optional email verification detail."""
+        """Abort setup with the most specific incomplete-account reason available.
+
+        Args:
+            step: Flow step where myAir reported incomplete account setup.
+            error: Original incomplete-account exception from the client.
+
+        Returns:
+            Config-flow abort result for Home Assistant.
+        """
         if self._client:
             try:
                 if not (await self._client.is_email_verified()):
@@ -156,7 +204,14 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: MutableMapping[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle the initial step."""
+        """Collect credentials, validate the account, and branch to MFA if needed.
+
+        Args:
+            user_input: Submitted username, password, and region values.
+
+        Returns:
+            Form, MFA step, abort, or created-entry result for Home Assistant.
+        """
         errors: dict[str, str] = {}
         user_input = user_input or {}
         if user_input:
@@ -216,7 +271,14 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_verify_mfa(
         self, user_input: MutableMapping[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Verify active MFA."""
+        """Verify MFA during initial setup and create the config entry.
+
+        Args:
+            user_input: Submitted verification code from the MFA form.
+
+        Returns:
+            MFA form, abort, or created-entry result for Home Assistant.
+        """
         errors: dict[str, str] = {}
         user_input = user_input or {}
         if user_input and isinstance(self._client, RESTClient):
@@ -261,7 +323,17 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_reauth(self, entry_data: MutableMapping[str, Any]) -> ConfigFlowResult:
-        """Handle configuration by re-auth."""
+        """Load the existing config entry before prompting for new credentials.
+
+        Args:
+            entry_data: Current config-entry data supplied by Home Assistant.
+
+        Returns:
+            Next reauth flow step.
+
+        Raises:
+            UnknownEntry: When Home Assistant no longer has the reauth entry.
+        """
         _LOGGER.info("Starting Reauthorization")
         entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         if entry:
@@ -277,7 +349,14 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reauth_confirm(
         self, user_input: MutableMapping[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Dialog that informs the user that reauth is required."""
+        """Collect replacement credentials and update the entry after validation.
+
+        Args:
+            user_input: Submitted username and password values.
+
+        Returns:
+            Reauth form, MFA step, abort, or successful-reauth abort result.
+        """
         errors: dict[str, str] = {}
 
         if user_input:
@@ -334,7 +413,14 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reauth_verify_mfa(
         self, user_input: MutableMapping[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Reauthorize access to ResMed myAir."""
+        """Complete MFA during reauth and reload the repaired config entry.
+
+        Args:
+            user_input: Submitted verification code from the reauth MFA form.
+
+        Returns:
+            Reauth MFA form, abort, or successful-reauth abort result.
+        """
         errors: dict[str, str] = {}
         user_input = user_input or {}
 

--- a/custom_components/resmed_myair/const.py
+++ b/custom_components/resmed_myair/const.py
@@ -1,4 +1,4 @@
-"""Constants for Home Assistant ResMed myAir Integration."""
+"""Home Assistant entity, config-entry, and redaction constants for myAir."""
 
 from collections.abc import Mapping
 

--- a/custom_components/resmed_myair/coordinator.py
+++ b/custom_components/resmed_myair/coordinator.py
@@ -16,7 +16,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 class MyAirDataUpdateCoordinator(DataUpdateCoordinator[MyAirCoordinatorData]):
-    """DataUpdateCoordinator for myAir."""
+    """Fetch and cache the typed myAir payload consumed by sensor entities."""
 
     myair_client: MyAirClient
 
@@ -26,7 +26,13 @@ class MyAirDataUpdateCoordinator(DataUpdateCoordinator[MyAirCoordinatorData]):
         config_entry: ConfigEntry,
         myair_client: MyAirClient,
     ) -> None:
-        """Initialize DataUpdateCoordinator for ResMed myAir."""
+        """Configure periodic myAir polling for a config entry.
+
+        Args:
+            hass: Home Assistant instance running the coordinator.
+            config_entry: myAir config entry associated with this coordinator.
+            myair_client: Client used to authenticate and fetch myAir data.
+        """
         _LOGGER.info("Initializing DataUpdateCoordinator for ResMed myAir")
         self.myair_client = myair_client
         super().__init__(
@@ -38,7 +44,14 @@ class MyAirDataUpdateCoordinator(DataUpdateCoordinator[MyAirCoordinatorData]):
         )
 
     async def _async_update_data(self) -> MyAirCoordinatorData:
-        """Fetch data from the myAir client and store it in the coordinator."""
+        """Refresh auth, device metadata, and recent sleep records.
+
+        Returns:
+            Typed coordinator payload containing any data available from myAir.
+
+        Raises:
+            ConfigEntryAuthFailed: When myAir authentication must be repaired by reauth.
+        """
         _LOGGER.info("Updating from myAir")
 
         try:

--- a/custom_components/resmed_myair/helpers.py
+++ b/custom_components/resmed_myair/helpers.py
@@ -1,4 +1,4 @@
-"""Helper functions for Home Assistant resmed_myair."""
+"""Integration-level compatibility exports for shared redaction helpers."""
 
 from .redaction import REDACTED, redact_dict
 

--- a/custom_components/resmed_myair/models.py
+++ b/custom_components/resmed_myair/models.py
@@ -13,7 +13,15 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 def _to_usage_minutes(raw_usage: Any) -> int | None:
-    """Convert API usage value to an integer minute count."""
+    """Normalize myAir ``totalUsage`` values into whole minutes.
+
+    Args:
+        raw_usage: API value that may arrive as an int, decimal-like string, float,
+            or malformed scalar.
+
+    Returns:
+        Whole usage minutes, or ``None`` when the payload cannot represent usage.
+    """
     if isinstance(raw_usage, bool):
         return None
     if isinstance(raw_usage, int):
@@ -34,7 +42,14 @@ def _to_usage_minutes(raw_usage: Any) -> int | None:
 
 
 def _format_usage_time(total_usage_minutes: int | None) -> str | None:
-    """Format usage minutes into friendly `H:MM` text."""
+    """Render usage minutes in the text format users expect in HA.
+
+    Args:
+        total_usage_minutes: Normalized CPAP usage minutes.
+
+    Returns:
+        ``H:MM`` text, or ``None`` when usage is unavailable.
+    """
     if total_usage_minutes is None:
         return None
 
@@ -43,14 +58,28 @@ def _format_usage_time(total_usage_minutes: int | None) -> str | None:
 
 
 def _to_optional_str(raw: Any) -> str | None:
-    """Return a normalized optional string value from arbitrary API payload data."""
+    """Keep string API fields while discarding unexpected payload types.
+
+    Args:
+        raw: Raw field value from a myAir payload.
+
+    Returns:
+        The string value, or ``None`` for missing and non-string values.
+    """
     if not isinstance(raw, str):
         return None
     return raw
 
 
 def _to_optional_date(raw: Any) -> date | None:
-    """Return a normalized optional date value from arbitrary API payload data."""
+    """Parse ISO date fields while tolerating malformed myAir payloads.
+
+    Args:
+        raw: Raw date field from a myAir payload.
+
+    Returns:
+        Parsed date, or ``None`` when the field is missing or invalid.
+    """
     if not isinstance(raw, str):
         return None
     try:
@@ -61,7 +90,7 @@ def _to_optional_date(raw: Any) -> date | None:
 
 @dataclass(frozen=True, slots=True)
 class MyAirDevice:
-    """Normalized typed representation of a device payload."""
+    """Typed view of the assigned flow-generator payload and its raw source."""
 
     raw: dict[str, Any]
     serial_number: str
@@ -71,7 +100,14 @@ class MyAirDevice:
 
     @classmethod
     def from_api(cls, data: Mapping[str, Any] | None) -> Self:
-        """Create a typed device from raw API payload data."""
+        """Build device metadata from a raw GraphQL device mapping.
+
+        Args:
+            data: Raw myAir device payload, or ``None`` when the API omitted it.
+
+        Returns:
+            Typed device with normalized serial, manufacturer, model, and name fields.
+        """
         raw = dict(data or {})
         serial_number = raw.get("serialNumber", "")
         if not isinstance(serial_number, str):
@@ -85,13 +121,20 @@ class MyAirDevice:
         )
 
     def native_value(self, key: str) -> Any | None:
-        """Return the raw payload value for a key or ``None``."""
+        """Read a sensor value from the original device payload.
+
+        Args:
+            key: GraphQL field name used by the sensor description.
+
+        Returns:
+            Raw payload value, or ``None`` when the key is absent.
+        """
         return self.raw.get(key)
 
 
 @dataclass(frozen=True, slots=True)
 class MyAirSleepRecord:
-    """Normalized typed representation of a sleep record payload."""
+    """Typed view of a nightly sleep record and its derived usage fields."""
 
     raw: dict[str, Any]
     start_date: date | None
@@ -101,7 +144,14 @@ class MyAirSleepRecord:
 
     @classmethod
     def from_api(cls, data: Mapping[str, Any] | None) -> Self:
-        """Create a typed sleep record from raw API payload data."""
+        """Build a sleep record from a raw GraphQL record mapping.
+
+        Args:
+            data: Raw myAir sleep-record payload, or ``None`` when unavailable.
+
+        Returns:
+            Typed record with parsed date, normalized minutes, and friendly usage text.
+        """
         raw = dict(data or {})
         total_usage_minutes = _to_usage_minutes(raw.get("totalUsage"))
         has_usage = total_usage_minutes is not None and total_usage_minutes > 0
@@ -114,27 +164,42 @@ class MyAirSleepRecord:
         )
 
     def native_value(self, key: str) -> Any | None:
-        """Return the raw payload value for a key or ``None``."""
+        """Read a sensor value from the original sleep-record payload.
+
+        Args:
+            key: GraphQL field name used by the sensor description.
+
+        Returns:
+            Raw payload value, or ``None`` when the key is absent.
+        """
         return self.raw.get(key)
 
 
 @dataclass(frozen=True, slots=True)
 class MyAirCoordinatorData:
-    """Typed coordinator payload wrapper for Home Assistant integration state."""
+    """Immutable snapshot of the latest myAir device and sleep data."""
 
     device: MyAirDevice | None = None
     sleep_records: tuple[MyAirSleepRecord, ...] = ()
 
     @property
     def latest_sleep_record(self) -> MyAirSleepRecord | None:
-        """Return the latest available sleep record if any."""
+        """Select the newest sleep record by start date.
+
+        Returns:
+            Most recent record, or ``None`` when the coordinator has no records.
+        """
         if not self.sleep_records:
             return None
         return max(self.sleep_records, key=lambda record: record.start_date or date.min)
 
     @property
     def most_recent_sleep_date(self) -> date | None:
-        """Return the most recent date that has recorded usage."""
+        """Find the newest sleep date with non-zero CPAP usage.
+
+        Returns:
+            Date of the most recent usage-bearing record, or ``None`` if none qualify.
+        """
         records_with_usage = [
             record for record in self.sleep_records if record.start_date and record.has_usage
         ]

--- a/custom_components/resmed_myair/sensor.py
+++ b/custom_components/resmed_myair/sensor.py
@@ -27,14 +27,30 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 def _coordinator_data(coordinator: MyAirDataUpdateCoordinator) -> MyAirCoordinatorData:
-    """Return typed coordinator data or an empty payload."""
+    """Normalize coordinator payloads before sensors read typed fields.
+
+    Args:
+        coordinator: Integration coordinator whose data may be unset during startup.
+
+    Returns:
+        Existing typed data, or an empty payload that keeps entity updates defensive.
+    """
     if isinstance(coordinator.data, MyAirCoordinatorData):
         return coordinator.data
     return MyAirCoordinatorData()
 
 
 def _parse_native_value(value: Any | None, description: SensorEntityDescription) -> Any | None:
-    """Parse native values for Home Assistant sensor device classes."""
+    """Convert raw API strings for Home Assistant date and timestamp sensors.
+
+    Args:
+        value: Raw value taken from a device or sleep-record payload.
+        description: Entity description that declares any HA device class.
+
+    Returns:
+        Parsed date/datetime values for matching device classes; otherwise the
+        original value.
+    """
     if isinstance(value, str) and description.device_class == SensorDeviceClass.DATE:
         return dt_util.parse_date(value)
     if isinstance(value, str) and description.device_class == SensorDeviceClass.TIMESTAMP:
@@ -47,7 +63,13 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up myAir sensors."""
+    """Create all myAir sensor entities and register the manual refresh service.
+
+    Args:
+        hass: Home Assistant instance receiving the entities and service.
+        config_entry: Loaded myAir config entry with coordinator runtime data.
+        async_add_entities: Home Assistant callback used to add entity instances.
+    """
     _LOGGER.debug(
         "[sensor async_setup_entry] config_entry.data: %s", redact_dict(config_entry.data)
     )
@@ -80,19 +102,18 @@ async def async_setup_entry(
     sanitized_username: str = config_entry.data[CONF_USER_NAME].replace("@", "_").replace(".", "_")
 
     async def refresh(_: Any) -> None:
+        """Refresh coordinator data when the per-account force-poll service runs.
+
+        Args:
+            _: Service call payload; unused because refresh needs no parameters.
+        """
         await coordinator.async_refresh()
 
     hass.services.async_register(DOMAIN, f"force_poll_{sanitized_username}", refresh)
 
 
 class MyAirBaseSensor(CoordinatorEntity, SensorEntity):
-    """Base sensor for ResMed myAir.
-
-    It knows the Friendly Name and key from the API response
-    for any particular sensor and keeps track of the coordinator.
-    All it really does is return that key from the newest
-    response that the coordinator has stored.
-    """
+    """Common entity identity and coordinator plumbing for myAir sensors."""
 
     def __init__(
         self,
@@ -100,7 +121,13 @@ class MyAirBaseSensor(CoordinatorEntity, SensorEntity):
         sensor_desc: SensorEntityDescription,
         coordinator: MyAirDataUpdateCoordinator,
     ) -> None:
-        """Create the CPAP sensors."""
+        """Build stable entity metadata from the device and sensor description.
+
+        Args:
+            friendly_name: Entity name shown in Home Assistant.
+            sensor_desc: Description containing the API key and HA metadata.
+            coordinator: Data coordinator that supplies device and sleep payloads.
+        """
         super().__init__(cast("DataUpdateCoordinator[dict[str, Any]]", coordinator))
         self.sensor_key: Final[str] = sensor_desc.key
         self.coordinator: MyAirDataUpdateCoordinator = coordinator
@@ -122,17 +149,17 @@ class MyAirBaseSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def available(self) -> bool:
-        """Return whether entity is available."""
+        """Report whether the last coordinator update produced a valid sensor value."""
         return self._available
 
     async def async_added_to_hass(self) -> None:
-        """Run once integration has been added to HA."""
+        """Populate the entity state immediately after Home Assistant adds it."""
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
 
 class MyAirSleepRecordSensor(MyAirBaseSensor):
-    """myAir Sleep Record sensor class."""
+    """Expose one field from the latest nightly sleep-record payload."""
 
     def __init__(
         self,
@@ -140,12 +167,18 @@ class MyAirSleepRecordSensor(MyAirBaseSensor):
         sensor_desc: SensorEntityDescription,
         coordinator: MyAirDataUpdateCoordinator,
     ) -> None:
-        """Initialize myAir Sleep Record sensor."""
+        """Create a sleep-record-backed entity.
+
+        Args:
+            friendly_name: Entity name shown in Home Assistant.
+            sensor_desc: Description whose key maps into a sleep-record payload.
+            coordinator: Data coordinator that supplies sleep records.
+        """
         super().__init__(friendly_name, sensor_desc, coordinator)
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
+        """Publish the selected field from the latest sleep record to HA state."""
         # The API always returns the previous month of data, so the client stores this
         # We assume this is ordered temporally and grab the last one: the latest one
         latest_record: MyAirSleepRecord | None = _coordinator_data(
@@ -170,7 +203,7 @@ class MyAirSleepRecordSensor(MyAirBaseSensor):
 
 
 class MyAirDeviceSensor(MyAirBaseSensor):
-    """myAir Device sensor class."""
+    """Expose one field from the assigned myAir device payload."""
 
     def __init__(
         self,
@@ -178,12 +211,18 @@ class MyAirDeviceSensor(MyAirBaseSensor):
         sensor_desc: SensorEntityDescription,
         coordinator: MyAirDataUpdateCoordinator,
     ) -> None:
-        """Initialize myAir Device sensor."""
+        """Create a device-payload-backed entity.
+
+        Args:
+            friendly_name: Entity name shown in Home Assistant.
+            sensor_desc: Description whose key maps into the device payload.
+            coordinator: Data coordinator that supplies device data.
+        """
         super().__init__(friendly_name, sensor_desc, coordinator)
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
+        """Publish the selected device field to HA state."""
         device_data: MyAirDevice | None = _coordinator_data(self.coordinator).device
         if device_data is None:
             _LOGGER.error("Device data missing from coordinator data")
@@ -204,20 +243,24 @@ class MyAirDeviceSensor(MyAirBaseSensor):
 
 
 class MyAirFriendlyUsageTime(MyAirBaseSensor):
-    """myAir Friendly Usage Time sensor class."""
+    """Expose the latest nightly usage as ``H:MM`` text."""
 
     def __init__(
         self,
         coordinator: MyAirDataUpdateCoordinator,
     ) -> None:
-        """Initialize myAir Friendly Usage Time sensor."""
+        """Create the synthesized friendly-usage sensor.
+
+        Args:
+            coordinator: Data coordinator that supplies sleep records.
+        """
         desc = SensorEntityDescription(key="usageTime")
 
         super().__init__("CPAP Usage Time", desc, coordinator)
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
+        """Publish formatted usage time from the latest sleep record."""
         latest_record: MyAirSleepRecord | None = _coordinator_data(
             self.coordinator
         ).latest_sleep_record
@@ -236,13 +279,17 @@ class MyAirFriendlyUsageTime(MyAirBaseSensor):
 
 
 class MyAirMostRecentSleepDate(MyAirBaseSensor):
-    """myAir Most Recent Sleep Date sensor class."""
+    """Expose the newest sleep date with recorded CPAP usage."""
 
     def __init__(
         self,
         coordinator: MyAirDataUpdateCoordinator,
     ) -> None:
-        """Initialize myAir Most Recent Sleep Date sensor."""
+        """Create the synthesized most-recent-sleep-date sensor.
+
+        Args:
+            coordinator: Data coordinator that supplies sleep records.
+        """
         desc = SensorEntityDescription(
             key="mostRecentSleepDate", device_class=SensorDeviceClass.DATE
         )
@@ -251,7 +298,7 @@ class MyAirMostRecentSleepDate(MyAirBaseSensor):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
+        """Publish the most recent usage-bearing sleep date to HA state."""
         value: date | None = _coordinator_data(self.coordinator).most_recent_sleep_date
         self._attr_native_value = value
         self._available = value is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared pytest fixtures used across the test suite."""
+"""Shared pytest fixtures, doubles, and harness shims for the test suite."""
 
 from collections.abc import Callable, Mapping
 from typing import Any, Protocol
@@ -29,7 +29,7 @@ type HeadersValue = Mapping[str, str] | CIMultiDict[str] | None
 
 
 class CoordinatorLike(Protocol):
-    """Protocol for the coordinator test doubles used by sensor tests."""
+    """Protocol for coordinator doubles that expose typed data and listeners."""
 
     data: MyAirCoordinatorData
 
@@ -38,7 +38,7 @@ class CoordinatorLike(Protocol):
 
 
 class CoordinatorFactory(Protocol):
-    """Factory protocol shared by coordinator fixtures and tests."""
+    """Protocol for fixtures that build either dataful coordinators or mocks."""
 
     def __call__(
         self,
@@ -52,7 +52,16 @@ def coordinator_data(
     device: dict[str, object] | None = None,
     sleep_records: list[dict[str, object]] | None = None,
 ) -> MyAirCoordinatorData:
-    """Build typed coordinator data for sensor tests."""
+    """Build typed coordinator data for sensor and integration tests.
+
+    Args:
+        device: Optional raw device payload to convert into typed model data.
+        sleep_records: Optional raw sleep-record payloads to convert into typed
+            model data.
+
+    Returns:
+        A `MyAirCoordinatorData` instance populated from the provided payloads.
+    """
     return MyAirCoordinatorData(
         device=MyAirDevice.from_api(device) if device is not None else None,
         sleep_records=tuple(MyAirSleepRecord.from_api(record) for record in (sleep_records or [])),
@@ -60,7 +69,15 @@ def coordinator_data(
 
 
 def _coordinator_data_from_mapping(data: dict[str, object] | None = None) -> MyAirCoordinatorData:
-    """Build typed coordinator data from legacy mapping payloads."""
+    """Build typed coordinator data from legacy mapping payloads.
+
+    Args:
+        data: Optional mapping containing raw `device` and `sleep_records`
+            members.
+
+    Returns:
+        A `MyAirCoordinatorData` instance with normalized model objects.
+    """
     if data is None:
         data = {
             "device": {
@@ -101,13 +118,13 @@ def _coordinator_data_from_mapping(data: dict[str, object] | None = None) -> MyA
 
 
 class ServiceEntryLike(Protocol):
-    """Protocol for service entries stored by the service registry shim."""
+    """Protocol for the minimal service-entry shape the shim stores."""
 
     handlers: list[Callable[..., object]]
 
 
 class ServiceRegistryShimLike(Protocol):
-    """Protocol for the lightweight service registry shim used in tests."""
+    """Protocol for the in-memory service registry used by setup tests."""
 
     _services: dict[str, dict[str, ServiceEntryLike]]
 
@@ -116,11 +133,7 @@ class ServiceRegistryShimLike(Protocol):
 
 
 def _ensure_config_entries_helpers(hass: Any) -> None:
-    """Ensure `hass.config_entries` exists and provides mockable helpers.
-
-    This centralizes the logic so tests and fixtures can call it without
-    duplicating guarded assignments that may clobber upstream mocks.
-    """
+    """Patch `hass.config_entries` with the async helpers the suite expects."""
     if not hasattr(hass, "config_entries") or hass.config_entries is None:
         hass.config_entries = MagicMock()
         # Provide the async_forward_entry_setups helper as awaitable
@@ -170,9 +183,15 @@ def make_mock_aiohttp_response(
     headers: HeadersValue = None,
     status: int = 200,
 ) -> MagicMock:
-    """Create a MagicMock that mimics an aiohttp response used in tests.
+    """Create a `ClientResponse`-shaped mock for aiohttp-based tests.
 
-    The returned object has async .json(), .headers and .status attributes.
+    Args:
+        json_value: Value returned by the mocked `json()` coroutine.
+        headers: Optional header mapping to expose on the mock response.
+        status: HTTP status code to assign to the mock response.
+
+    Returns:
+        A `MagicMock` that behaves like an aiohttp response object.
     """
     mock_res = MagicMock(spec=ClientResponse)
     mock_res.json = AsyncMock(return_value=json_value)
@@ -203,8 +222,13 @@ def make_mock_aiohttp_context_manager(
 ) -> AsyncMock:
     """Return an async context manager that yields a mock aiohttp response.
 
-    Useful for assigning to session.get/post return values in tests:
-        session.post.return_value = make_mock_aiohttp_context_manager({...})
+    Args:
+        json_value: JSON payload or prebuilt response object to yield.
+        headers: Optional header mapping for the generated response mock.
+        status: HTTP status code to assign to the generated response mock.
+
+    Returns:
+        An `AsyncMock` that can back `session.get()` or `session.post()`.
     """
     # If caller passed a prebuilt MagicMock response, return a context manager that yields it.
     if isinstance(json_value, MagicMock):
@@ -220,13 +244,13 @@ def make_mock_aiohttp_context_manager(
 
 @pytest.fixture
 def session() -> MagicMock:
-    """Return a MagicMock that can be used as an aiohttp ClientSession in tests."""
+    """Return a `ClientSession`-spec mock for request-layer tests."""
     return MagicMock(spec=ClientSession)
 
 
 @pytest.fixture
 def config_entry(hass: Any) -> MockConfigEntry:
-    """Return a MockConfigEntry configured with realistic default data and attach it to hass."""
+    """Return a default `MockConfigEntry` and wire it into Home Assistant."""
     data = {
         CONF_USER_NAME: "test@example.com",
         CONF_PASSWORD: "dummy_password",
@@ -259,14 +283,7 @@ def config_entry(hass: Any) -> MockConfigEntry:
 
 @pytest.fixture(autouse=True)
 def configure_hass(hass: Any) -> None:
-    """Ensure the phcc-provided `hass` fixture has the attributes tests expect.
-
-    Many tests assume `hass.config_entries.async_forward_entry_setups` is
-    awaitable and returns True, and that `hass.services` exists. This
-    autouse fixture mutates the real `hass` fixture (provided by pytest-
-    homeassistant-custom-component) so those expectations hold without
-    replacing the full Home Assistant test harness.
-    """
+    """Patch the shared `hass` fixture with the async helpers tests expect."""
     # Centralize and reuse the guarded setup logic.
     _ensure_config_entries_helpers(hass)
 
@@ -278,22 +295,10 @@ def configure_hass(hass: Any) -> None:
 
 @pytest.fixture
 def service_registry_shim(hass: Any, monkeypatch: pytest.MonkeyPatch) -> ServiceRegistryShimLike:
-    """Provide a lightweight ServiceRegistry shim mounted at ``hass.services``.
-
-    The shim implements a minimal subset of Home Assistant's ServiceRegistry
-    API used by tests:
-      - ``has_service(domain, service) -> bool``
-      - ``async_register(domain, service, func, schema=None, ...)``
-
-    Registered handlers are stored in ``shim._services[domain][service].handlers``
-    which mirrors the structure tests inspect in the original code.
-
-    The fixture monkeypatches ``hass.services`` with the shim and returns the
-    shim object so tests may directly inspect or reuse it.
-    """
+    """Provide a lightweight `hass.services` shim for service-registration tests."""
 
     class _ServiceEntry:
-        """Container for handlers registered under one service name."""
+        """Store callbacks registered for a single Home Assistant service."""
 
         def __init__(self) -> None:
             """Initialize the service entry with no registered handlers."""
@@ -307,7 +312,7 @@ def service_registry_shim(hass: Any, monkeypatch: pytest.MonkeyPatch) -> Service
             self._services: dict[str, dict[str, _ServiceEntry]] = {}
 
         def has_service(self, domain: str, service: str) -> bool:
-            """Return whether a service exists in the requested domain."""
+            """Return whether a service has been registered for a domain."""
             return domain in self._services and service in self._services[domain]
 
         def async_register(
@@ -322,7 +327,7 @@ def service_registry_shim(hass: Any, monkeypatch: pytest.MonkeyPatch) -> Service
             """Register a handler for the requested domain and service.
 
             Args:
-                domain: Home Assistant service domain.
+                domain: Home Assistant service domain being registered.
                 service: Service name within the domain.
                 func: Handler callback to store for later assertions.
                 schema: Optional service schema accepted for API compatibility.
@@ -343,10 +348,7 @@ def service_registry_shim(hass: Any, monkeypatch: pytest.MonkeyPatch) -> Service
 
 @pytest.fixture
 def myair_client() -> MagicMock:
-    """Return a MagicMock that mimics the myAir client used by coordinators.
-
-    It provides AsyncMock implementations for the common async methods used in tests.
-    """
+    """Return a `RESTClient`-spec mock with the async methods coordinators call."""
     # Use spec=RESTClient so tests that isinstance-check against RESTClient continue to work
     client = MagicMock(spec=RESTClient)
     client.connect = AsyncMock()
@@ -357,41 +359,49 @@ def myair_client() -> MagicMock:
 
 @pytest.fixture
 def config_na() -> MyAirConfig:
-    """Return a MyAirConfig for the NA region used by REST client tests."""
+    """Return an NA-region `MyAirConfig` for REST client tests."""
     return MyAirConfig(username="user", password="pass", region=REGION_NA, device_token="token")
 
 
 @pytest.fixture
 def config_eu() -> MyAirConfig:
-    """Return a MyAirConfig for the EU region used by REST client tests."""
+    """Return an EU-region `MyAirConfig` for REST client tests."""
     return MyAirConfig(username="user", password="pass", region=REGION_EU, device_token="token")
 
 
 @pytest.fixture
 def coordinator(coordinator_factory: CoordinatorFactory) -> CoordinatorLike | MagicMock:
-    """Return the default dataful coordinator via the factory (convenience wrapper)."""
+    """Return the default dataful coordinator from the shared factory."""
     return coordinator_factory()
 
 
 @pytest.fixture
 def coordinator_mock(coordinator_factory: CoordinatorFactory) -> MagicMock:
-    """Return an AsyncMock coordinator via the factory (convenience wrapper)."""
+    """Return a mock coordinator with async refresh hooks."""
     return coordinator_factory(mock=True)
 
 
 @pytest.fixture
 def coordinator_factory() -> CoordinatorFactory:
-    """Factory fixture that produces coordinator objects.
+    """Build coordinator doubles for tests.
 
-    Usage:
-      - coordinator_factory() -> dataful DummyCoordinator (default)
-      - coordinator_factory(mock=True) -> AsyncMock coordinator
-      - coordinator_factory(data=...) -> DummyCoordinator with custom data
+    Returns:
+        A callable that can create a dataful dummy coordinator or an async
+        mock coordinator, depending on the requested flags.
     """
 
     def _make(
         mock: bool = False, data: dict[str, object] | MyAirCoordinatorData | None = None
     ) -> CoordinatorLike | MagicMock:
+        """Create either an async mock coordinator or a data-backed dummy.
+
+        Args:
+            mock: Whether to return a ``MagicMock`` with async refresh methods.
+            data: Optional mapping or typed payload for the dummy coordinator.
+
+        Returns:
+            Coordinator test double suitable for sensor and setup tests.
+        """
         if mock:
             m = MagicMock()
             m.async_refresh = AsyncMock()
@@ -406,10 +416,22 @@ def coordinator_factory() -> CoordinatorFactory:
             payload = _coordinator_data_from_mapping(data)
 
         class DummyCoordinator:
+            """Minimal coordinator shape that lets CoordinatorEntity register listeners."""
+
             def __init__(self, d: MyAirCoordinatorData) -> None:
+                """Store the typed payload exposed through ``coordinator.data``.
+
+                Args:
+                    d: Typed coordinator payload used by sensor tests.
+                """
                 self.data = d
 
             def async_add_listener(self, *args: object, **kwargs: object) -> Callable[[], None]:
+                """Accept listener registration and return a no-op unsubscribe callback.
+
+                Returns:
+                    Callable matching Home Assistant's listener-removal contract.
+                """
                 return lambda: None
 
         return DummyCoordinator(payload)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,15 @@ class CoordinatorLike(Protocol):
     data: MyAirCoordinatorData
 
     def async_add_listener(self, *args: object, **kwargs: object) -> Callable[[], None]:
-        """Register a listener callback and return an unsubscribe callback."""
+        """Accept Home Assistant listener registration on coordinator doubles.
+
+        Args:
+            *args: Listener callback arguments supplied by `CoordinatorEntity`.
+            **kwargs: Listener registration options supplied by Home Assistant.
+
+        Returns:
+            Callable that removes the listener when invoked.
+        """
 
 
 class CoordinatorFactory(Protocol):
@@ -45,7 +53,15 @@ class CoordinatorFactory(Protocol):
         mock: bool = False,
         data: dict[str, object] | MyAirCoordinatorData | None = None,
     ) -> CoordinatorLike | MagicMock:
-        """Return either a dataful coordinator double or a mock coordinator."""
+        """Create the requested coordinator shape for a test.
+
+        Args:
+            mock: Whether the caller needs async refresh methods on a mock object.
+            data: Optional payload for a data-backed coordinator double.
+
+        Returns:
+            Coordinator double matching the requested test scenario.
+        """
 
 
 def coordinator_data(
@@ -129,7 +145,15 @@ class ServiceRegistryShimLike(Protocol):
     _services: dict[str, dict[str, ServiceEntryLike]]
 
     def has_service(self, domain: str, service: str) -> bool:
-        """Return whether the service was registered."""
+        """Check whether setup registered a named service.
+
+        Args:
+            domain: Home Assistant service domain.
+            service: Service name within the domain.
+
+        Returns:
+            Whether the in-memory registry contains that service.
+        """
 
 
 def _ensure_config_entries_helpers(hass: Any) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,4 +1,4 @@
-"""Tests for the integration config flow behavior and edge cases."""
+"""Config-flow tests that protect setup, MFA, and reauth state transitions."""
 
 from unittest.mock import AsyncMock, MagicMock
 
@@ -30,7 +30,7 @@ from custom_components.resmed_myair.models import MyAirDevice
 
 @pytest.fixture
 def flow(hass: MagicMock) -> MyAirConfigFlow:
-    """Fixture for MyAirConfigFlow instance."""
+    """Return a configured `MyAirConfigFlow` bound to the test Home Assistant."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow.context = {}
@@ -41,7 +41,7 @@ def flow(hass: MagicMock) -> MyAirConfigFlow:
 async def test_async_step_user_success(
     flow: MyAirConfigFlow, myair_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test successful user step."""
+    """A successful user step creates an entry with the discovered device."""
     user_input: dict[str, str] = {
         CONF_USER_NAME: "user",
         CONF_PASSWORD: "pass",
@@ -72,7 +72,7 @@ async def test_async_step_user_success(
 async def test_async_step_user_auth_error(
     flow: MyAirConfigFlow, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test user step with authentication error."""
+    """Authentication failures keep the user step on the form with an error."""
     user_input: dict[str, str] = {
         CONF_USER_NAME: "user",
         CONF_PASSWORD: "badpass",
@@ -93,7 +93,7 @@ async def test_async_step_user_auth_error(
 async def test_async_step_verify_mfa_user_input_and_client(
     monkeypatch: pytest.MonkeyPatch, hass: MagicMock, myair_client: MagicMock
 ) -> None:
-    """Verify MFA step with valid user input leads to create_entry."""
+    """Valid MFA input completes setup and persists the device token."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {}
@@ -137,7 +137,7 @@ async def test_async_step_verify_mfa_error(
     monkeypatch: pytest.MonkeyPatch,
     is_restclient: bool,
 ) -> None:
-    """Test MFA verification step with error for RESTClient and non-RESTClient clients."""
+    """MFA failures map to the correct form error for client types."""
     # Use a real RESTClient instance for one case, and a non-spec MagicMock for the other
     flow._client = myair_client if is_restclient else MagicMock()
     flow._data = {CONF_USER_NAME: "user"}
@@ -161,7 +161,7 @@ async def test_async_step_verify_mfa_error(
 
 @pytest.mark.asyncio
 async def test_async_step_user_form_display(flow: MyAirConfigFlow) -> None:
-    """Test that the user form is shown when no input is provided."""
+    """Missing user input keeps the user step on its form."""
     result = await flow.async_step_user()
     assert result["type"] == "form"
     assert result["step_id"] == "user"
@@ -172,7 +172,7 @@ async def test_async_step_user_form_display(flow: MyAirConfigFlow) -> None:
 async def test_async_step_verify_mfa_form_display(
     flow: MyAirConfigFlow, myair_client: MagicMock
 ) -> None:
-    """Test that the MFA form is shown when no input is provided."""
+    """Missing MFA input keeps the verification step on its form."""
     flow._client = myair_client
     flow._data = {CONF_USER_NAME: "user"}
     result = await flow.async_step_verify_mfa()
@@ -196,7 +196,7 @@ async def test_async_step_forms_display_parametrized(
     expected_step_id: str,
     myair_client: MagicMock,
 ) -> None:
-    """Parametrized: form display checks for multiple steps."""
+    """User and MFA steps both render their forms when called without input."""
     if pre_setup:
         flow._client = myair_client
         flow._data = {CONF_USER_NAME: "user"}
@@ -211,7 +211,7 @@ async def test_async_step_forms_display_parametrized(
 async def test_async_step_verify_mfa_incomplete_account(
     flow: MyAirConfigFlow, myair_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test MFA step aborts if account is incomplete."""
+    """Incomplete accounts abort MFA verification after the email check."""
     flow._client = myair_client
     flow._data = {CONF_USER_NAME: "user"}
     user_input: dict[str, str] = {CONF_VERIFICATION_CODE: "123456"}
@@ -229,7 +229,7 @@ async def test_async_step_verify_mfa_incomplete_account(
 
 @pytest.mark.asyncio
 async def test_async_step_reauth_confirm_form_display(flow: MyAirConfigFlow) -> None:
-    """Test that the reauth confirm form is shown when no input is provided."""
+    """Missing reauth input keeps the confirm step on its form."""
     flow._data = {CONF_USER_NAME: "user", CONF_PASSWORD: "pass"}
     result = await flow.async_step_reauth_confirm()
     assert result["type"] == "form"
@@ -241,7 +241,7 @@ async def test_async_step_reauth_confirm_form_display(flow: MyAirConfigFlow) -> 
 async def test_async_step_reauth_verify_mfa_form_display(
     flow: MyAirConfigFlow, myair_client: MagicMock
 ) -> None:
-    """Test that the reauth verify MFA form is shown when no input is provided."""
+    """Missing reauth MFA input keeps verification on its form."""
     flow._client = myair_client
     flow._data = {CONF_USER_NAME: "user"}
     result = await flow.async_step_reauth_verify_mfa()
@@ -257,7 +257,7 @@ async def test_async_step_reauth_success(
     myair_client: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test reauth step completes successfully."""
+    """Successful reauth updates the stored credentials and completes."""
     flow._data = {CONF_USER_NAME: "user", CONF_PASSWORD: "pass", CONF_REGION: REGION_NA}
     device = MyAirDevice.from_api(
         {
@@ -290,7 +290,7 @@ async def test_async_step_reauth_success(
 async def test_async_step_reauth_confirm_mfa(
     flow: MyAirConfigFlow, config_entry: MockConfigEntry, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test reauth confirm step triggers MFA if needed."""
+    """Reauth confirm triggers MFA when the account still requires it."""
     flow._data = {CONF_USER_NAME: "user", CONF_PASSWORD: "pass", CONF_REGION: REGION_NA}
     flow._entry = config_entry
     monkeypatch.setattr(
@@ -336,7 +336,7 @@ async def test_async_step_reauth_incomplete_account_parametrized(
     config_entry: MockConfigEntry,
     myair_client: MagicMock,
 ) -> None:
-    """Parametrized test covering incomplete-account behavior for reauth steps.
+    """Reauth steps abort or surface MFA prompts for incomplete accounts.
 
     Depending on the step, the flow uses either `get_device` or `get_mfa_device`.
     This single test exercises both `async_step_reauth_confirm` and
@@ -398,7 +398,7 @@ async def test_async_step_reauth_verify_mfa_success(
     myair_client: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test reauth verify MFA step completes successfully."""
+    """Successful reauth MFA verification updates the stored credentials."""
     flow._client = myair_client
     flow._data = {CONF_USER_NAME: "user", CONF_PASSWORD: "pass"}
     flow._entry = config_entry
@@ -429,7 +429,7 @@ async def test_async_step_reauth_verify_mfa_error(
     myair_client: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test reauth verify MFA step with error."""
+    """Reauth MFA failures return the form with an MFA error."""
     flow._client = myair_client
     flow._data = {CONF_USER_NAME: "user", CONF_PASSWORD: "pass"}
     flow._entry = config_entry
@@ -468,7 +468,7 @@ async def test_async_step_reauth_verify_mfa_incomplete_account_parametrized(
     config_entry: MockConfigEntry,
     myair_client: MagicMock,
 ) -> None:
-    """Parametrized: Test async_step_reauth_verify_mfa aborts or shows form for incomplete account in all branches."""
+    """Reauth MFA branches either abort or keep the form for incomplete accounts."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {
@@ -534,7 +534,7 @@ async def test_get_device_variants(
     myair_client: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test get_device behavior across connection and device data variants."""
+    """`get_device` handles connection outcomes and device payload variants."""
     mock_client = myair_client
     if isinstance(connect_return, Exception):
         mock_client.connect = AsyncMock(side_effect=connect_return)
@@ -600,7 +600,7 @@ async def test_get_mfa_device_variants(
     raises: type[BaseException] | None,
     myair_client: MagicMock,
 ) -> None:
-    """Test get_mfa_device behavior across MFA and device-data branches."""
+    """`get_mfa_device` handles MFA outcomes and follow-up device fetches."""
     mock_client = myair_client
     if verify_side_effect:
         mock_client.verify_mfa_and_get_access_token = AsyncMock(side_effect=verify_side_effect)
@@ -633,7 +633,7 @@ async def test_get_mfa_device_variants(
 async def test_get_device_passes_device_token(
     hass: MagicMock, myair_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test get_device passes device_token to MyAirConfig."""
+    """`get_device` forwards the device token into `MyAirConfig`."""
     mock_client = myair_client
     mock_client.connect = AsyncMock(return_value=AUTHN_SUCCESS)
     mock_client.get_user_device_data = AsyncMock(return_value=MyAirDevice.from_api({}))
@@ -652,7 +652,7 @@ async def test_get_device_passes_device_token(
 async def test_async_step_verify_mfa_success(
     flow: MyAirConfigFlow, myair_client: RESTClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test successful MFA verification step creates entry with correct data."""
+    """Successful MFA verification creates the entry with the persisted token."""
     flow._client = myair_client
     flow._data = {CONF_USER_NAME: "user"}
     user_input: dict[str, str] = {CONF_VERIFICATION_CODE: "123456"}
@@ -691,7 +691,7 @@ async def test_async_step_verify_mfa_status_variants(
     myair_client: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: verify that when MFA status is not AUTHN_SUCCESS the flow shows the correct form and error."""
+    """Non-success MFA statuses keep the flow on the correct error form."""
     flow._client = myair_client
     flow._data = {CONF_USER_NAME: "user"}
     user_input = {CONF_VERIFICATION_CODE: "badcode"}
@@ -713,7 +713,7 @@ async def test_async_step_verify_mfa_status_variants(
 async def test_async_step_verify_mfa_auth_error_exception(
     flow: MyAirConfigFlow, myair_client: RESTClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test async_step_verify_mfa shows form with error on AuthenticationError."""
+    """Authentication errors keep MFA verification on the form."""
     flow._client = myair_client
     flow._data = {CONF_USER_NAME: "user"}
     user_input = {CONF_VERIFICATION_CODE: "badcode"}
@@ -733,7 +733,7 @@ async def test_async_step_verify_mfa_auth_error_exception(
 async def test_async_step_verify_mfa_no_user_input_shows_form(
     flow: MyAirConfigFlow,
 ) -> None:
-    """Test async_step_verify_mfa shows form if no user_input is provided."""
+    """Missing MFA input keeps verification on the form."""
     # Intentionally use a non-spec MagicMock here so the flow treats the
     # client as NOT an instance of RESTClient (forces the non-RESTClient path).
     flow._client = MagicMock()
@@ -748,7 +748,7 @@ async def test_async_step_verify_mfa_no_user_input_shows_form(
 async def test_async_step_reauth_calls_confirm(
     hass: MagicMock, config_entry: MockConfigEntry
 ) -> None:
-    """Ensure reauth entry route calls the reauth confirm step and populates data."""
+    """The reauth entry route loads entry data before calling confirm."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow.context = {"entry_id": "123"}
@@ -772,7 +772,7 @@ async def test_async_step_reauth_calls_confirm(
 async def test_async_step_user_not_device_or_not_authn_success(
     monkeypatch: pytest.MonkeyPatch, hass: MagicMock
 ) -> None:
-    """Test async_step_user when NOT (device and status == AUTHN_SUCCESS)."""
+    """A non-success device lookup advances the flow to MFA verification."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {}
@@ -800,7 +800,7 @@ async def test_async_step_user_not_device_or_not_authn_success(
 async def test_async_step_user_device_missing_serial_number(
     monkeypatch: pytest.MonkeyPatch, hass: MagicMock
 ) -> None:
-    """Test async_step_user shows form with error if 'serialNumber' not in device."""
+    """Missing device serial numbers keep the user step on its form."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {}
@@ -828,7 +828,7 @@ async def test_async_step_user_device_missing_serial_number(
 async def test_async_step_verify_mfa_parsing_error(
     monkeypatch: pytest.MonkeyPatch, hass: MagicMock, myair_client: MagicMock
 ) -> None:
-    """Test async_step_verify_mfa handles ParsingError and shows form with error."""
+    """Parsing errors keep MFA verification on the form with an error."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {}
@@ -854,7 +854,7 @@ async def test_async_step_reauth_verify_mfa_user_input_and_restclient(
     config_entry: MockConfigEntry,
     myair_client: MagicMock,
 ) -> None:
-    """Test async_step_reauth_verify_mfa covers if user_input and isinstance(self._client, RESTClient)."""
+    """Reauth MFA completion persists the device token for REST clients."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {}
@@ -896,7 +896,7 @@ async def test_async_step_reauth_verify_mfa_parsing_error(
     config_entry: MockConfigEntry,
     myair_client: MagicMock,
 ) -> None:
-    """Test async_step_reauth_verify_mfa handles ParsingError and shows form with error."""
+    """Parsing errors keep reauth MFA on the form with an error."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {}
@@ -920,7 +920,7 @@ async def test_async_step_reauth_verify_mfa_parsing_error(
 async def test_async_step_verify_mfa_incomplete_account_new(
     monkeypatch: pytest.MonkeyPatch, hass: MagicMock, myair_client: MagicMock
 ) -> None:
-    """Test async_step_verify_mfa handles IncompleteAccountError and aborts."""
+    """Incomplete-account MFA failures abort after the email check."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {}
@@ -946,7 +946,7 @@ async def test_async_step_verify_mfa_incomplete_account_new(
 
 @pytest.mark.asyncio
 async def test_async_step_reauth_no_entry(hass: MagicMock) -> None:
-    """Test async_step_reauth raises UnknownEntry if entry is not found."""
+    """Reauth aborts when the referenced config entry no longer exists."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     # Simulate async_get_entry returning None
@@ -962,7 +962,7 @@ async def test_async_step_reauth_no_entry(hass: MagicMock) -> None:
 async def test_async_step_reauth_confirm_missing_serial_number(
     monkeypatch: pytest.MonkeyPatch, hass: MagicMock, config_entry: MockConfigEntry
 ) -> None:
-    """Test async_step_reauth_confirm shows form with error if 'serialNumber' not in device."""
+    """Missing device serial numbers keep reauth confirm on its form."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {
@@ -1007,7 +1007,7 @@ async def test_async_step_reauth_confirm_exceptions(
     hass: MagicMock,
     config_entry: MockConfigEntry,
 ) -> None:
-    """Parametrized: reauth confirm maps client exceptions to form errors/abort reasons."""
+    """Reauth confirm maps client exceptions to the expected error path."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {
@@ -1041,7 +1041,7 @@ async def test_async_step_reauth_confirm_exceptions(
 async def test_async_step_verify_mfa_incomplete_account_email_check_exception(
     monkeypatch: pytest.MonkeyPatch, hass: MagicMock, myair_client: MagicMock
 ) -> None:
-    """Test async_step_verify_mfa IncompleteAccountError with ParsingError in is_email_verified."""
+    """Parsing errors in the email check preserve the incomplete-account abort."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {}
@@ -1080,7 +1080,7 @@ async def test_async_step_user_incomplete_account_parametrized(
     hass: MagicMock,
     myair_client: MagicMock,
 ) -> None:
-    """Parametrized: Test async_step_user aborts for incomplete account in all branches."""
+    """User-step incomplete-account branches all converge on aborts."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {CONF_USER_NAME: "user"}
@@ -1124,7 +1124,7 @@ async def test_async_step_user_incomplete_account_email_check_transport_error(
     myair_client: MagicMock,
     email_error: Exception,
 ) -> None:
-    """Transient email-verification transport failures should preserve the abort."""
+    """Transient email-check transport failures still preserve the abort."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {CONF_USER_NAME: "user"}
@@ -1148,7 +1148,7 @@ async def test_async_step_user_incomplete_account_email_check_transport_error(
 async def test_async_step_verify_mfa_incomplete_account_email_verified(
     monkeypatch: pytest.MonkeyPatch, hass: MagicMock, myair_client: MagicMock
 ) -> None:
-    """Test async_step_verify_mfa IncompleteAccountError with is_email_verified True (NOT branch)."""
+    """Verified email state still aborts incomplete-account MFA attempts."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {CONF_USER_NAME: "user"}
@@ -1175,7 +1175,7 @@ async def test_async_step_verify_mfa_incomplete_account_email_verified(
 async def test_async_step_verify_mfa_status_not_authn_success(
     monkeypatch: pytest.MonkeyPatch, hass: MagicMock, myair_client: MagicMock
 ) -> None:
-    """Test async_step_verify_mfa when status is NOT AUTHN_SUCCESS (should show form with mfa_error)."""
+    """Non-success MFA statuses keep verification on the error form."""
     flow = MyAirConfigFlow()
     flow.hass = hass
     flow._data = {CONF_USER_NAME: "user"}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,4 +1,4 @@
-"""Unit tests for the coordinator that updates myAir data."""
+"""Coordinator tests that protect refresh, auth, and parse fallbacks."""
 
 from unittest.mock import MagicMock
 
@@ -16,7 +16,7 @@ from custom_components.resmed_myair.models import (
 
 @pytest.mark.asyncio
 async def test_async_update_data_success(hass: MagicMock, myair_client: MagicMock) -> None:
-    """Coordinator returns device and sleep_records on success."""
+    """Successful refreshes return both device data and sleep records."""
     myair_client.get_user_device_data.return_value = MyAirDevice.from_api(
         {
             "serialNumber": "1234",
@@ -43,7 +43,7 @@ async def test_async_update_data_success(hass: MagicMock, myair_client: MagicMoc
 
 @pytest.mark.asyncio
 async def test_async_update_data_auth_error(hass: MagicMock, myair_client: MagicMock) -> None:
-    """AuthenticationError in client.connect should raise ConfigEntryAuthFailed."""
+    """Authentication failures surface as config-entry auth errors."""
     myair_client.connect.side_effect = AuthenticationError("bad creds")
     coordinator = MyAirDataUpdateCoordinator(hass, MagicMock(), myair_client)
     # Only assert that the correct exception type is raised. The exact
@@ -58,7 +58,7 @@ async def test_async_update_data_auth_error(hass: MagicMock, myair_client: Magic
 async def test_async_update_data_parsing_error_device(
     hass: MagicMock, myair_client: MagicMock
 ) -> None:
-    """ParsingError during device data fetch results in empty device dict."""
+    """Device parsing failures degrade to an empty device payload."""
     myair_client.get_sleep_records.return_value = [
         MyAirSleepRecord.from_api({"totalUsage": 60, "startDate": "2024-07-01"})
     ]
@@ -79,7 +79,7 @@ async def test_async_update_data_parsing_error_device(
 async def test_async_update_data_parsing_error_sleep_records(
     hass: MagicMock, myair_client: MagicMock
 ) -> None:
-    """ParsingError during sleep record fetch results in empty sleep_records list."""
+    """Sleep-record parsing failures degrade to an empty record list."""
     myair_client.get_user_device_data.return_value = MyAirDevice.from_api(
         {"serialNumber": "1234", "fgDeviceManufacturerName": "ResMed"}
     )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,4 @@
-"""Parametrized tests for both client and integration helpers."""
+"""Shared redaction tests that exercise both helper import paths."""
 
 import importlib
 from typing import Any
@@ -52,10 +52,15 @@ MODULE_IDS = [p.replace("custom_components.resmed_myair.", "") for p in MODULE_P
 
 
 def _replace_placeholder(obj: Any, placeholder: str, replacement: Any) -> Any:
-    """Recursively replace placeholder strings in expected structures.
+    """Recursively replace placeholder values in nested expected structures.
 
-    This allows writing expected values with a sentinel and then substituting
-    the actual module REDACTED constant at test time.
+    Args:
+        obj: Nested object graph to traverse.
+        placeholder: Sentinel string to replace.
+        replacement: Value to substitute for the sentinel.
+
+    Returns:
+        A structure with matching placeholder strings replaced in place.
     """
     if isinstance(obj, str):
         return replacement if obj == placeholder else obj
@@ -70,12 +75,7 @@ def _replace_placeholder(obj: Any, placeholder: str, replacement: Any) -> Any:
 
 @pytest.mark.parametrize("module_path", MODULE_PATHS, ids=MODULE_IDS)
 def test_redact_dict_equivalence(monkeypatch: pytest.MonkeyPatch, module_path: str) -> None:
-    """Run the common redact_dict test vectors against both implementations.
-
-    The test monkeypatches the shared redaction module KEYS_TO_REDACT and
-    swaps the '<REDACTED>' sentinel in the expected outputs with the module's
-    REDACTED constant.
-    """
+    """Both helper modules redact the same nested values and sentinels."""
     module = importlib.import_module(module_path)
     monkeypatch.setattr(
         redaction,
@@ -93,7 +93,7 @@ def test_redact_dict_equivalence(monkeypatch: pytest.MonkeyPatch, module_path: s
 
 @pytest.mark.parametrize("module_path", MODULE_PATHS, ids=MODULE_IDS)
 def test_redact_dict_empty_and_trivial(monkeypatch: pytest.MonkeyPatch, module_path: str) -> None:
-    """Ensure redact_dict handles empty/trivial inputs for both implementations."""
+    """Both helper modules leave empty and trivial containers unchanged."""
     module = importlib.import_module(module_path)
     monkeypatch.setattr(
         redaction,
@@ -108,7 +108,7 @@ def test_redact_dict_empty_and_trivial(monkeypatch: pytest.MonkeyPatch, module_p
 
 @pytest.mark.parametrize("module_path", MODULE_PATHS, ids=MODULE_IDS)
 def test_helpers_reexport_shared_redactor_and_constants(module_path: str) -> None:
-    """Both helper import paths expose the shared redactor and redaction constant."""
+    """Both helper import paths re-export the shared redactor constant."""
     module = importlib.import_module(module_path)
 
     assert module.redact_dict is redaction.redact_dict

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,4 @@
-"""Tests for package initialization logic, including migration helpers."""
+"""Package-initialization tests that protect config-entry migration behavior."""
 
 from unittest.mock import MagicMock
 
@@ -11,7 +11,7 @@ from custom_components.resmed_myair.const import CONF_REGION, REGION_NA
 
 @pytest.mark.asyncio
 async def test_async_migrate_entry_version_1(hass: MagicMock) -> None:
-    """Migrate from version 1 should add CONF_REGION and update entry."""
+    """Version 1 entries gain the region field during migration."""
     # Create a MockConfigEntry at version 1 to exercise migration logic
     entry = MockConfigEntry(
         domain="resmed_myair", title="ResMed-CPAP", data={"foo": "bar"}, version=1
@@ -33,7 +33,7 @@ async def test_async_migrate_entry_version_1(hass: MagicMock) -> None:
 
 @pytest.mark.asyncio
 async def test_async_migrate_entry_version_2_noop(hass: MagicMock) -> None:
-    """Migrate from version 2 should be a no-op and not call async_update_entry."""
+    """Version 2 entries remain unchanged and skip config-entry updates."""
     entry = MockConfigEntry(
         domain="resmed_myair", title="ResMed-CPAP", data={"foo": "bar"}, version=2
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,4 @@
-"""Tests for the resmed_myair integration (integration-level unit tests)."""
+"""Integration-level tests for setup, unload, migration, and sensor wiring."""
 
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
@@ -43,7 +43,7 @@ async def test_async_setup_entry_refresh_failure(
     session: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test integration setup entry raises if first refresh fails."""
+    """Setup propagates refresh failures before forwarding platforms."""
     # Replace async_create_clientsession to return the provided session
     monkeypatch.setattr(
         resmed_module, "async_create_clientsession", lambda *args, **kwargs: session
@@ -72,7 +72,7 @@ async def test_async_setup_entry_multiple_calls(
     session: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test async_setup_entry can be called multiple times without error."""
+    """Setup remains idempotent across repeated calls for the same entry."""
     monkeypatch.setattr(
         resmed_module, "async_create_clientsession", lambda *args, **kwargs: session
     )
@@ -98,7 +98,7 @@ async def test_async_setup_entry_multiple_calls(
 async def test_friendly_usage_time_sensor_with_negative_usage(
     hass: MagicMock, coordinator_factory: CoordinatorFactory
 ) -> None:
-    """Test MyAirFriendlyUsageTime handles negative usage values."""
+    """Friendly usage sensors clamp negative minutes to zero."""
     coordinator = coordinator_factory(data={"sleep_records": [{"totalUsage": -10}]})
     sensor = MyAirFriendlyUsageTime(coordinator)
     sensor.hass = hass
@@ -113,7 +113,7 @@ async def test_friendly_usage_time_sensor_with_negative_usage(
 async def test_most_recent_sleep_date_sensor_with_future_date(
     hass: MagicMock, coordinator_factory: CoordinatorFactory
 ) -> None:
-    """Test MyAirMostRecentSleepDate handles future dates."""
+    """Most-recent sleep date sensors preserve future-dated records."""
     future = (datetime.now(UTC).date() + timedelta(days=10)).isoformat()
 
     coordinator = coordinator_factory(
@@ -130,7 +130,7 @@ async def test_most_recent_sleep_date_sensor_with_future_date(
 
 @pytest.mark.asyncio
 async def test_async_migrate_entry_v2(hass: MagicMock, config_entry: MockConfigEntry) -> None:
-    """Test migration does nothing for version 2."""
+    """Version 2 config entries skip migration updates."""
     # The shared `config_entry` fixture is already a MockConfigEntry at version 2.
     hass.config_entries.async_update_entry = MagicMock()
     result = await async_migrate_entry(hass, config_entry)
@@ -156,7 +156,7 @@ async def test_async_unload_entry_variants(
     expected_result: object,
     expected_runtime_data: object,
 ) -> None:
-    """Test async_unload_entry returns correct result and preserves runtime_data."""
+    """Unload returns the platform result without clearing runtime data."""
     hass.config_entries.async_unload_platforms = AsyncMock(return_value=unload_return)
     config_entry.runtime_data = initial_runtime_data
     result1 = await async_unload_entry(hass, config_entry)
@@ -173,7 +173,7 @@ async def test_async_unload_entry_variants(
 async def test_async_unload_entry_calls_unload_platforms(
     hass: MagicMock, config_entry: MockConfigEntry
 ) -> None:
-    """Test async_unload_entry calls async_unload_platforms and returns True."""
+    """Unload delegates to `async_unload_platforms` and returns success."""
     hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
     config_entry.runtime_data = "dummy"
     result = await async_unload_entry(hass, config_entry)
@@ -185,7 +185,7 @@ async def test_async_unload_entry_calls_unload_platforms(
 async def test_sleep_record_sensor_multiple_updates(
     hass: MagicMock, coordinator: CoordinatorLike
 ) -> None:
-    """Test MyAirSleepRecordSensor updates value on multiple coordinator updates."""
+    """Sleep-record sensors follow successive coordinator payload updates."""
     key = "CPAP Usage Minutes"
     desc = SLEEP_RECORD_SENSOR_DESCRIPTIONS[key]
     sensor = MyAirSleepRecordSensor(key, desc, coordinator)
@@ -215,7 +215,7 @@ async def test_sleep_record_sensor_multiple_updates(
 async def test_device_sensor_multiple_updates(
     hass: MagicMock, coordinator: CoordinatorLike
 ) -> None:
-    """Test MyAirDeviceSensor updates value on multiple coordinator updates."""
+    """Device sensors follow successive coordinator payload updates."""
     key = "CPAP Sleep Data Last Collected"
     desc = DEVICE_SENSOR_DESCRIPTIONS[key]
     sensor = MyAirDeviceSensor(key, desc, coordinator)
@@ -247,7 +247,7 @@ async def test_device_sensor_multiple_updates(
 async def test_friendly_usage_time_sensor_multiple_updates(
     hass: MagicMock, coordinator: CoordinatorLike
 ) -> None:
-    """Test MyAirFriendlyUsageTime sensor updates formatted usage time on data change."""
+    """Friendly usage sensors reformat minutes after each data change."""
     sensor = MyAirFriendlyUsageTime(coordinator)
     sensor.hass = hass
     sensor.entity_id = "sensor.test_friendly_usage"
@@ -275,7 +275,7 @@ async def test_friendly_usage_time_sensor_multiple_updates(
 async def test_most_recent_sleep_date_sensor_multiple_updates(
     hass: MagicMock, coordinator: CoordinatorLike
 ) -> None:
-    """Test MyAirMostRecentSleepDate sensor updates date as new records are added."""
+    """Most-recent sleep date sensors advance as new usable records appear."""
     sensor = MyAirMostRecentSleepDate(coordinator)
     sensor.hass = hass
     sensor.entity_id = "sensor.test_recent_sleep"
@@ -345,7 +345,7 @@ async def test_sensor_becomes_unavailable_on_missing_data(
     data_field: str,
     empty_value: object,
 ) -> None:
-    """Test sensors become unavailable when their data is missing."""
+    """Entities go unavailable when the backing payload disappears."""
     sensor = sensor_class(key, desc, coordinator)
     sensor.hass = hass
     sensor.entity_id = f"sensor.test_{key.replace(' ', '_').lower()}"
@@ -440,7 +440,7 @@ async def test_sensor_handles_empty_or_missing_data(
     expected_available: bool,
     coordinator_factory: CoordinatorFactory,
 ) -> None:
-    """Test sensors handle empty or missing data gracefully."""
+    """Entities remain safe when their coordinator payload is empty."""
     coordinator = coordinator_factory(data=coordinator_data)
     if sensor_class in (MyAirSleepRecordSensor, MyAirDeviceSensor):
         sensor = sensor_class(key, desc, coordinator)
@@ -456,7 +456,7 @@ async def test_sensor_handles_empty_or_missing_data(
 
 # Home Assistant calls this through an AsyncMock side effect during setup tests.
 async def fake_forward_entry_setups(config_entry: MockConfigEntry, platforms: list[str]) -> None:
-    """Forward sensor platform setups during tests using the provided config entry."""
+    """Forward sensor platform setup calls using the test config entry."""
     # Use the hass from config_entry, which is set by Home Assistant during setup
     hass = config_entry.hass
     if "sensor" in platforms:
@@ -470,7 +470,7 @@ async def test_force_poll_service_triggers_refresh(
     coordinator_factory: CoordinatorFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that the force_poll service calls coordinator.async_refresh()."""
+    """The force-poll service directly triggers a coordinator refresh."""
     # Use the centralized factory to create a mock coordinator with the
     # attributes tests expect (async_refresh, async_config_entry_first_refresh, .data)
     dummy_coordinator = coordinator_factory(mock=True)
@@ -483,6 +483,15 @@ async def test_force_poll_service_triggers_refresh(
     domains = []
 
     def register(domain: str, name: str, func: object, *args: object, **kwargs: object) -> None:
+        """Capture service registration arguments for force-poll assertions.
+
+        Args:
+            domain: Home Assistant service domain being registered.
+            name: Service name derived from the account username.
+            func: Service callback registered by the integration.
+            *args: Additional Home Assistant service registration arguments.
+            **kwargs: Additional Home Assistant service registration options.
+        """
         registered[name] = func
         domains.append(domain)
 
@@ -520,7 +529,7 @@ async def test_force_poll_service_triggers_refresh(
 async def test_sensor_unique_id_and_device_info(
     hass: MagicMock, coordinator: CoordinatorLike
 ) -> None:
-    """Test that sensors have unique_id and correct device info."""
+    """Sensors expose stable unique IDs and manufacturer device metadata."""
     key = "CPAP Usage Minutes"
     desc = SLEEP_RECORD_SENSOR_DESCRIPTIONS[key]
     sensor = MyAirSleepRecordSensor(key, desc, coordinator)
@@ -537,10 +546,16 @@ async def test_sensor_unique_id_and_device_info(
 async def test_async_setup_entry_registers_all_sensors(
     hass: MagicMock, config_entry: MockConfigEntry, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test async_setup_entry adds all expected sensor entities."""
+    """Setup registers every device, sleep, and synthesized sensor entity."""
     added_entities = []
 
     def fake_add_entities(entities: list[object], update_before_add: bool) -> None:
+        """Collect entities that setup passes to Home Assistant.
+
+        Args:
+            entities: Sensor entities created by ``async_setup_entry``.
+            update_before_add: Whether HA should update entities before adding them.
+        """
         assert isinstance(update_before_add, bool)
         added_entities.extend(entities)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,4 @@
-"""Tests for typed ResMed myAir domain models."""
+"""Model-level tests covering typed ResMed myAir payload behavior."""
 
 from datetime import date
 from decimal import Decimal
@@ -14,7 +14,7 @@ from custom_components.resmed_myair.models import (
 
 
 def test_device_preserves_raw_values_and_device_info_fields() -> None:
-    """Device model exposes stable fields while preserving raw API data."""
+    """Device parsing preserves raw fields used for entity identity and labels."""
     device = MyAirDevice.from_api(
         {
             "serialNumber": "123",
@@ -35,7 +35,7 @@ def test_device_preserves_raw_values_and_device_info_fields() -> None:
 
 
 def test_sleep_record_parses_usage_and_start_date() -> None:
-    """Sleep record model exposes typed convenience values."""
+    """Sleep records expose typed convenience values for usage and dates."""
     record = MyAirSleepRecord.from_api(
         {
             "startDate": "2024-07-18",
@@ -51,7 +51,7 @@ def test_sleep_record_parses_usage_and_start_date() -> None:
 
 
 def test_negative_usage_is_clamped_for_friendly_display() -> None:
-    """Negative usage values display as zero usage."""
+    """Negative usage values are clamped to zero for display helpers."""
     record = MyAirSleepRecord.from_api({"startDate": "2024-07-18", "totalUsage": -5})
 
     assert record.total_usage_minutes == -5
@@ -59,7 +59,7 @@ def test_negative_usage_is_clamped_for_friendly_display() -> None:
 
 
 def test_coordinator_data_exposes_latest_and_most_recent_used_date() -> None:
-    """Coordinator data exposes the latest record and most recent used date."""
+    """Coordinator data derives the latest record and most recent used date."""
     data = MyAirCoordinatorData(
         device=MyAirDevice.from_api({"serialNumber": "123"}),
         sleep_records=(
@@ -74,7 +74,7 @@ def test_coordinator_data_exposes_latest_and_most_recent_used_date() -> None:
 
 
 def test_device_fields_default_to_empty_or_none_for_missing_values() -> None:
-    """Missing keys should not crash model construction."""
+    """Missing device keys collapse to empty or `None` values."""
     device = MyAirDevice.from_api({})
 
     assert device.raw == {}
@@ -85,14 +85,14 @@ def test_device_fields_default_to_empty_or_none_for_missing_values() -> None:
 
 
 def test_device_ignores_non_string_serial_number() -> None:
-    """Non-string serial numbers should not be coerced to text."""
+    """Non-string serial numbers are ignored instead of coerced to text."""
     device = MyAirDevice.from_api({"serialNumber": None})
 
     assert device.serial_number == ""
 
 
 def test_device_fields_with_non_string_optional_values_are_none() -> None:
-    """Non-string optional fields should become None."""
+    """Non-string optional device fields normalize to `None`."""
     device = MyAirDevice.from_api(
         {
             "fgDeviceManufacturerName": 123,
@@ -107,7 +107,7 @@ def test_device_fields_with_non_string_optional_values_are_none() -> None:
 
 
 def test_sleep_record_with_missing_fields_defaults() -> None:
-    """Missing usage and date values should be safe defaults."""
+    """Missing sleep-record fields fall back to safe defaults."""
     record = MyAirSleepRecord.from_api({})
 
     assert record.start_date is None
@@ -117,7 +117,7 @@ def test_sleep_record_with_missing_fields_defaults() -> None:
 
 
 def test_sleep_record_with_non_string_start_date_has_none_start_date() -> None:
-    """Non-string startDate values should not be parsed."""
+    """Non-string `startDate` values are skipped during parsing."""
     record = MyAirSleepRecord.from_api({"startDate": 123, "totalUsage": 30})
 
     assert record.start_date is None
@@ -127,7 +127,7 @@ def test_sleep_record_with_non_string_start_date_has_none_start_date() -> None:
 
 
 def test_sleep_record_with_invalid_start_date_has_none_start_date() -> None:
-    """Invalid startDate strings should not crash model construction."""
+    """Invalid `startDate` strings leave the parsed date unset."""
     record = MyAirSleepRecord.from_api({"startDate": "not-a-date", "totalUsage": 30})
 
     assert record.start_date is None
@@ -135,7 +135,7 @@ def test_sleep_record_with_invalid_start_date_has_none_start_date() -> None:
 
 
 def test_device_from_api_accepts_none() -> None:
-    """from_api accepts None and produces a safe empty device."""
+    """`from_api(None)` returns an empty, safe device model."""
     device = MyAirDevice.from_api(None)
 
     assert device.raw == {}
@@ -146,7 +146,7 @@ def test_device_from_api_accepts_none() -> None:
 
 
 def test_sleep_record_from_api_accepts_none() -> None:
-    """from_api accepts None and produces a safe empty record."""
+    """`from_api(None)` returns an empty, safe sleep-record model."""
     record = MyAirSleepRecord.from_api(None)
 
     assert record.raw == {}
@@ -157,7 +157,7 @@ def test_sleep_record_from_api_accepts_none() -> None:
 
 
 def test_most_recent_sleep_date_skips_zero_usage_records() -> None:
-    """Most recent sleep date should ignore records with zero usage."""
+    """Zero-usage sleep records do not affect the most recent date."""
     data = MyAirCoordinatorData(
         device=None,
         sleep_records=(
@@ -172,7 +172,7 @@ def test_most_recent_sleep_date_skips_zero_usage_records() -> None:
 
 
 def test_sleep_record_with_non_int_usage_is_none() -> None:
-    """Non-int usage values should not be treated as usage minutes."""
+    """Non-integer usage values are ignored instead of coerced."""
     record = MyAirSleepRecord.from_api({"startDate": "2024-07-18", "totalUsage": True})
 
     assert record.total_usage_minutes is None
@@ -184,7 +184,7 @@ def test_sleep_record_with_non_int_usage_is_none() -> None:
 def test_sleep_record_coerces_numeric_usage_values(
     raw_usage: float | Decimal | str, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Numeric API usage values should be coerced to integer minutes."""
+    """Numeric usage values are coerced to whole minutes."""
     with caplog.at_level(logging.INFO):
         record = MyAirSleepRecord.from_api({"startDate": "2024-07-18", "totalUsage": raw_usage})
 
@@ -198,7 +198,7 @@ def test_sleep_record_coerces_numeric_usage_values(
 def test_sleep_record_does_not_log_for_integral_numeric_usage(
     raw_usage: float | Decimal | str, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Integral numeric API usage values should not log truncation."""
+    """Integral numeric usage values skip truncation logging."""
     with caplog.at_level(logging.INFO):
         record = MyAirSleepRecord.from_api({"startDate": "2024-07-18", "totalUsage": raw_usage})
 
@@ -207,7 +207,7 @@ def test_sleep_record_does_not_log_for_integral_numeric_usage(
 
 
 def test_coordinator_data_selects_latest_record_by_start_date() -> None:
-    """Coordinator data should not rely on API sleep record order."""
+    """Latest sleep data is selected by date rather than list order."""
     data = MyAirCoordinatorData(
         sleep_records=(
             MyAirSleepRecord.from_api({"startDate": "2024-07-20", "totalUsage": 0}),
@@ -222,7 +222,7 @@ def test_coordinator_data_selects_latest_record_by_start_date() -> None:
 
 
 def test_coordinator_data_defaults_to_empty() -> None:
-    """Coordinator data should construct when payload members are omitted."""
+    """Coordinator data still constructs when payload members are omitted."""
     data = MyAirCoordinatorData()
 
     assert data.device is None

--- a/tests/test_oauth_helper_spike.py
+++ b/tests/test_oauth_helper_spike.py
@@ -1,10 +1,10 @@
-"""Tests documenting OAuth helper feasibility for ResMed myAir."""
+"""OAuth-helper feasibility checks for ResMed myAir redirect URLs."""
 
 from custom_components.resmed_myair.client.rest_client import EU_CONFIG, NA_CONFIG
 
 
 def test_resmed_registered_redirect_urls_are_external() -> None:
-    """ResMed's app redirect URLs are not Home Assistant callback URLs."""
+    """ResMed's registered redirect URLs stay outside the Home Assistant callback path."""
     redirect_urls = {
         NA_CONFIG.oauth_redirect_url,
         EU_CONFIG.oauth_redirect_url,

--- a/tests/test_prek_autoupdate_workflow.py
+++ b/tests/test_prek_autoupdate_workflow.py
@@ -1,4 +1,4 @@
-"""Tests for the prek autoupdate workflow."""
+"""Prek-autoupdate workflow tests that protect cleanup and permissions logic."""
 
 from collections.abc import Generator
 from importlib import util
@@ -29,7 +29,7 @@ class FakeCleanupClient:
         closed_pulls: list[dict[str, object]],
         fail_on_close: bool = False,
     ) -> None:
-        """Initialize fake pull request state.
+        """Initialize fake pull-request state for cleanup assertions.
 
         Args:
             open_pulls: Pull requests to return for open PR lookups.
@@ -45,18 +45,18 @@ class FakeCleanupClient:
         self.max_pages_by_state: dict[str, int | None] = {}
 
     def list_pulls(self, *, state: str, max_pages: int | None = None) -> list[dict[str, object]]:
-        """Return fake pull requests by state."""
+        """Return fake pull requests for the requested state."""
         self.max_pages_by_state[state] = max_pages
         return self.open_pulls if state == "open" else self.closed_pulls
 
     def close_pull(self, pull_number: int) -> None:
-        """Record or reject a closed pull request."""
+        """Record a closed pull request unless the test marked it protected."""
         if self.fail_on_close:
             raise AssertionError(f"Unexpected close for PR {pull_number}")
         self.closed_prs.append(pull_number)
 
     def delete_ref(self, ref: str) -> None:
-        """Record a deleted git ref."""
+        """Record a deleted git ref for later assertions."""
         self.deleted_refs.append(ref)
 
 
@@ -69,7 +69,7 @@ def _workflow_pull(
     body: str = WORKFLOW_BODY_MARKER,
     merged_at: str | None = None,
 ) -> dict[str, object]:
-    """Return a fake workflow pull request object.
+    """Return a fake workflow pull-request object.
 
     Args:
         number: Pull request number.
@@ -147,17 +147,17 @@ def cleanup_script() -> Generator[ModuleType]:
     ],
 )
 def test_workflow_contains_expected_cleanup_logic(needle: str, reason: str) -> None:
-    """Workflow should include standalone cleanup logic for generated prek PRs."""
+    """Workflow text includes the cleanup logic needed for generated prek PRs."""
     assert needle in WORKFLOW_PATH.read_text(), reason
 
 
 def test_workflow_avoids_inline_repository_template_expansion() -> None:
-    """Workflow should not expand the repository context inside shell scripts."""
+    """Workflow shell snippets avoid inlining repository context values."""
     assert '--repository "${{ github.repository }}"' not in WORKFLOW_PATH.read_text()
 
 
 def test_workflow_scopes_write_permissions_to_update_job() -> None:
-    """Workflow should grant write permissions only to the mutating job."""
+    """Only the update job receives write permissions."""
     workflow = WORKFLOW_PATH.read_text()
     jobs_index = workflow.index("jobs:")
     root_block = workflow[:jobs_index]
@@ -173,7 +173,7 @@ def test_workflow_scopes_write_permissions_to_update_job() -> None:
 def test_cleanup_script_closes_stale_prs_and_deletes_workflow_branches(
     cleanup_script: ModuleType,
 ) -> None:
-    """Cleanup script should close stale PRs and remove workflow-created branches."""
+    """Cleanup closes stale PRs and removes workflow-created branches."""
     client = FakeCleanupClient(
         open_pulls=[
             _workflow_pull(number=10),
@@ -217,7 +217,7 @@ def test_cleanup_script_closes_stale_prs_and_deletes_workflow_branches(
 
 
 def test_cleanup_script_keeps_active_update_branch(cleanup_script: ModuleType) -> None:
-    """Cleanup script should not delete the branch for the kept update PR."""
+    """Cleanup leaves the active update branch untouched."""
     client = FakeCleanupClient(
         open_pulls=[_workflow_pull(number=12)],
         closed_pulls=[
@@ -253,7 +253,7 @@ def test_cleanup_script_keeps_active_update_branch(cleanup_script: ModuleType) -
 def test_cleanup_script_preserves_human_prs_with_matching_label_and_prefix(
     cleanup_script: ModuleType,
 ) -> None:
-    """Cleanup script should not mutate human PRs that share labels and prefixes."""
+    """Cleanup skips human-authored PRs that match bot labels and prefixes."""
     client = FakeCleanupClient(
         open_pulls=[
             _workflow_pull(
@@ -295,7 +295,7 @@ def test_cleanup_script_preserves_human_prs_with_matching_label_and_prefix(
 def test_cleanup_script_preserves_bot_prs_without_workflow_body_marker(
     cleanup_script: ModuleType,
 ) -> None:
-    """Cleanup script should not mutate bot PRs without the workflow body marker."""
+    """Cleanup skips bot PRs that lack the workflow body marker."""
     client = FakeCleanupClient(
         open_pulls=[
             _workflow_pull(
@@ -335,7 +335,7 @@ def test_cleanup_script_preserves_bot_prs_without_workflow_body_marker(
 
 
 def test_github_headers_include_json_content_type(cleanup_script: ModuleType) -> None:
-    """GitHub client headers should describe JSON request bodies correctly."""
+    """GitHub requests declare JSON content types for cleanup API calls."""
     headers = cleanup_script._github_headers("token")
 
     assert headers["Content-Type"] == "application/json"

--- a/tests/test_pytest_coverage_workflow.py
+++ b/tests/test_pytest_coverage_workflow.py
@@ -1,4 +1,4 @@
-"""Tests for the pytest coverage workflow guardrails."""
+"""Pytest-coverage workflow tests that protect checkout safety settings."""
 
 from pathlib import Path
 
@@ -7,7 +7,7 @@ WORKFLOW_PATH = REPO_ROOT / ".github/workflows/pytest_coverage.yml"
 
 
 def test_checkout_does_not_persist_credentials() -> None:
-    """Checkout should not leave pull request credentials in the git config."""
+    """Workflow checkout disables persisted git credentials."""
     workflow = WORKFLOW_PATH.read_text()
     checkout_step = "- name: Checkout Repository"
     next_step = "- name: Debug GitHub Variables"

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,4 +1,4 @@
-"""Tests for shared ResMed myAir redaction helpers."""
+"""Redaction tests that protect nested secret-stripping behavior."""
 
 from types import MappingProxyType
 
@@ -6,7 +6,7 @@ from custom_components.resmed_myair.redaction import REDACTED, redact_dict
 
 
 def test_redact_dict_redacts_nested_sensitive_values() -> None:
-    """Sensitive keys are redacted inside mappings and lists."""
+    """Sensitive keys are redacted inside nested mappings and lists."""
     data = {
         "Username": "person@example.com",
         "nested": [{"access_token": "token-value"}, {"safe": "value"}],
@@ -21,18 +21,18 @@ def test_redact_dict_redacts_nested_sensitive_values() -> None:
 
 
 def test_redact_dict_redacts_given_name() -> None:
-    """The myAir given_name claim is redacted."""
+    """The myAir `given_name` claim is always redacted."""
     assert redact_dict({"given_name": "Alice"}) == {"given_name": REDACTED}
 
 
 def test_redact_dict_redacts_nested_immutable_mappings() -> None:
-    """Immutable nested mappings should be copied and redacted."""
+    """Immutable nested mappings are copied before redaction."""
     data = {"nested": MappingProxyType({"access_token": "token-value"})}
 
     assert redact_dict(data) == {"nested": {"access_token": REDACTED}}
 
 
 def test_redact_dict_returns_non_collection_values_unchanged() -> None:
-    """Scalar values are returned unchanged."""
+    """Scalar values pass through the redactor unchanged."""
     assert redact_dict("plain") == "plain"
     assert redact_dict(None) is None

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,4 +1,4 @@
-"""Tests for the release workflow guardrails."""
+"""Release-workflow tests that protect versioning and tag-update behavior."""
 
 from importlib import util
 import json
@@ -16,7 +16,7 @@ WORKFLOW_SCRIPT_PATH = ".github/scripts/update_release_version.py"
 
 @pytest.fixture
 def release_version_script() -> ModuleType:
-    """Load the release version update script as a test module."""
+    """Load the checked-in release version script as an importable module."""
     spec = util.spec_from_file_location("update_release_version", SCRIPT_PATH)
     assert spec is not None
     assert spec.loader is not None
@@ -34,7 +34,7 @@ def release_version_script() -> ModuleType:
 
 
 def test_edited_release_checkout_uses_release_tag() -> None:
-    """Edited releases should package the existing release tag."""
+    """Edited release runs continue from the published release tag."""
     workflow = WORKFLOW_PATH.read_text()
 
     assert (
@@ -43,7 +43,7 @@ def test_edited_release_checkout_uses_release_tag() -> None:
 
 
 def test_release_workflow_serializes_tag_updates() -> None:
-    """Release runs that update tags should not overlap."""
+    """Tag-updating release runs serialize via workflow concurrency."""
     workflow = WORKFLOW_PATH.read_text()
 
     assert "concurrency:" in workflow
@@ -52,7 +52,7 @@ def test_release_workflow_serializes_tag_updates() -> None:
 
 
 def test_published_release_checkout_uses_release_tag() -> None:
-    """Published releases should package the tag created for the release."""
+    """Published release builds check out the tag created for that release."""
     workflow = WORKFLOW_PATH.read_text()
     checkout_step = "- name: Checkout Repository"
     update_version_step = "- name: Update Release Version Files"
@@ -68,7 +68,7 @@ def test_published_release_checkout_uses_release_tag() -> None:
 
 
 def test_release_shell_steps_use_tag_environment_variable() -> None:
-    """Shell commands should quote the release tag from the environment."""
+    """Shell steps quote the release tag before moving or pushing it."""
     workflow = WORKFLOW_PATH.read_text()
     shell_step_names = [
         "Update Release Version Files",
@@ -92,7 +92,7 @@ def test_release_shell_steps_use_tag_environment_variable() -> None:
 
 
 def test_release_workflow_runs_checked_in_version_update_script() -> None:
-    """Release workflow should delegate version file updates to the script."""
+    """Release workflow delegates version-file edits to the checked-in script."""
     workflow = WORKFLOW_PATH.read_text()
     step_label = "- name: Update Release Version Files"
 
@@ -112,7 +112,7 @@ def test_release_version_script_updates_manifest_and_const(
     tmp_path: Path,
     release_version_script: ModuleType,
 ) -> None:
-    """Version update script should update both release metadata files."""
+    """The version update script rewrites both manifest and const metadata."""
     manifest_path = tmp_path / "manifest.json"
     const_path = tmp_path / "const.py"
     manifest_path.write_text(json.dumps({"domain": "resmed_myair", "version": "v0.1.0"}))
@@ -133,7 +133,7 @@ def test_release_version_script_rejects_missing_const_version(
     tmp_path: Path,
     release_version_script: ModuleType,
 ) -> None:
-    """Version update script should fail when const.py lacks a VERSION assignment."""
+    """The version update script rejects const.py files without `VERSION`."""
     manifest_path = tmp_path / "manifest.json"
     const_path = tmp_path / "const.py"
     manifest_path.write_text(json.dumps({"domain": "resmed_myair", "version": "v0.1.0"}))
@@ -148,7 +148,7 @@ def test_release_version_script_rejects_missing_const_version(
 
 
 def test_edited_release_does_not_force_move_tag() -> None:
-    """Edited releases should not commit version changes or force-move tags."""
+    """Edited releases skip version commits and avoid force-moving tags."""
     workflow = WORKFLOW_PATH.read_text()
 
     guarded_steps = [

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -1,4 +1,4 @@
-"""Unit tests for the REST client used by the resmed_myair integration."""
+"""REST client tests that protect auth, GraphQL, and parsing behavior."""
 
 import datetime
 import logging
@@ -34,7 +34,7 @@ from tests.conftest import make_mock_aiohttp_context_manager, make_mock_aiohttp_
 
 
 def test_get_region_config_returns_na_settings() -> None:
-    """NA region lookup returns the existing ResMed endpoints."""
+    """NA region lookups return the expected ResMed endpoint set."""
     config = get_region_config(REGION_NA)
 
     assert isinstance(config, RegionConfig)
@@ -44,7 +44,7 @@ def test_get_region_config_returns_na_settings() -> None:
 
 
 def test_get_region_config_returns_eu_settings() -> None:
-    """EU region lookup returns the existing ResMed endpoints."""
+    """EU region lookups return the expected ResMed endpoint set."""
     config = get_region_config(REGION_EU)
 
     assert isinstance(config, RegionConfig)
@@ -54,12 +54,12 @@ def test_get_region_config_returns_eu_settings() -> None:
 
 
 def test_get_region_config_fallback_to_eu_for_unknown_region() -> None:
-    """Unexpected region values default to EU settings."""
+    """Unknown region values fall back to the EU configuration."""
     assert get_region_config("unexpected") == EU_CONFIG
 
 
 def test_rest_client_owns_auth_session(config_na: MyAirConfig, session: MagicMock) -> None:
-    """RESTClient composes a dedicated auth session."""
+    """RESTClient builds a dedicated auth session wrapper."""
     client = RESTClient(config_na, session)
 
     assert isinstance(client._auth, MyAirAuthSession)
@@ -67,7 +67,7 @@ def test_rest_client_owns_auth_session(config_na: MyAirConfig, session: MagicMoc
 
 
 def test_rest_client_owns_graphql_client(config_na: MyAirConfig, session: MagicMock) -> None:
-    """RESTClient composes a dedicated GraphQL client."""
+    """RESTClient builds a dedicated GraphQL client wrapper."""
     client = RESTClient(config_na, session)
 
     assert isinstance(client._graphql, MyAirGraphQLClient)
@@ -79,7 +79,7 @@ def test_rest_client_owns_graphql_client(config_na: MyAirConfig, session: MagicM
 def test_rest_client_init_region(
     region: str, expected_config: RegionConfig, session: MagicMock
 ) -> None:
-    """Test RESTClient initialization for both NA and EU regions."""
+    """RESTClient initialization selects the expected regional settings."""
     config = MyAirConfig(username="user", password="pass", region=region, device_token="token")
     client = RESTClient(config, session)
     assert client._region_config == expected_config
@@ -89,7 +89,7 @@ def test_rest_client_init_region(
 
 @pytest.mark.parametrize("case", ["device_token", "cookies"])
 def test_properties_variants(case: str, config_na: MyAirConfig, session: MagicMock) -> None:
-    """Parametrized: small property checks for device_token and _cookies."""
+    """Device-token and cookie properties mirror the client state."""
     client = RESTClient(config_na, session)
     if case == "device_token":
         assert client.device_token == "token"
@@ -139,7 +139,7 @@ async def test_extract_and_update_cookies_variants(
     config_na: MyAirConfig,
     session: MagicMock,
 ) -> None:
-    """Parametrized test for _extract_and_update_cookies covering all branches, including warning."""
+    """Cookie extraction updates state, handles casing, and logs rotations safely."""
     # MyAirConfig is a NamedTuple (immutable) so use _replace to change device_token
     config = config_na._replace(device_token=None)
     client = RESTClient(config, session)
@@ -194,7 +194,7 @@ async def test_extract_and_update_cookies_variants(
 async def test_resmed_response_error_check_variants(
     status: int, resp_dict: dict[str, object], expected_exception: type[BaseException]
 ) -> None:
-    """Parametrized tests for various error responses in _resmed_response_error_check."""
+    """Response error parsing maps auth and incomplete-account failures correctly."""
     response = MagicMock(spec=ClientResponse)
     response.status = status
     response.headers = CIMultiDict()
@@ -250,7 +250,7 @@ async def test_authn_check_variants(
     expect_mfa_url_prefix: str | None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized tests for _authn_check success and MFA_REQUIRED paths."""
+    """Auth checks handle success and MFA-required payloads."""
     client = RESTClient(config_na, session)
     mock_response = make_mock_aiohttp_response(json_value=json_value)
     session.post.return_value = make_mock_aiohttp_context_manager(mock_response)
@@ -276,7 +276,7 @@ async def test_authn_check_invalid_status_raises(
     json_value: dict[str, object],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: _authn_check should raise AuthenticationError for invalid status payloads."""
+    """Invalid auth status payloads raise `AuthenticationError`."""
     client = RESTClient(config_na, session)
     mock_response = make_mock_aiohttp_response(json_value=json_value)
     session.post.return_value = make_mock_aiohttp_context_manager(mock_response)
@@ -301,7 +301,7 @@ async def test_verify_mfa_and_get_access_token_variants(
     expected_status: str | None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: verify_mfa_and_get_access_token success and failure paths."""
+    """MFA verification either returns the status or raises on failure."""
     client = RESTClient(config_na, session)
     # use monkeypatch to replace instance methods
     client_verify = AsyncMock(return_value=verify_return)
@@ -321,7 +321,7 @@ async def test_verify_mfa_and_get_access_token_variants(
 async def test_connect_access_token_active_variants(
     config_na: MyAirConfig, session: MagicMock, cookie_dt: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Parametrized: connect returns AUTHN_SUCCESS when access token is active (different cookie values)."""
+    """Active access tokens short-circuit connect to `AUTHN_SUCCESS`."""
     client = RESTClient(config_na, session)
     client._cookie_dt = cookie_dt
     client._access_token = "token"
@@ -337,7 +337,7 @@ async def test_connect_access_token_active_variants(
 async def test_connect_authn_success(
     config_na: MyAirConfig, session: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test connect calls _authn_check and _get_access_token on success."""
+    """Connect performs auth checks before requesting a new access token."""
     client = RESTClient(config_na, session)
     client._cookie_dt = "dt"
     client._access_token = None
@@ -367,7 +367,7 @@ async def test_connect_needs_mfa_parametrized(
     expect_raises: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: connect behavior when MFA is required for initial True/False."""
+    """Connect triggers MFA only on the initial auth path that requires it."""
     client = RESTClient(config_na, session)
     client._cookie_dt = "dt"
     client._access_token = None
@@ -405,7 +405,7 @@ async def test_connect_initial_dt_and_warning_variants(
     expect_warn: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: when _cookie_dt is None the client should call _get_initial_dt; when _uses_mfa is True it logs a warning."""
+    """Connect fetches an initial DT cookie and warns when MFA is active."""
     client = RESTClient(config_na, session)
     client._cookie_dt = None
     client._uses_mfa = uses_mfa
@@ -442,7 +442,7 @@ async def test_connect_status_needs_mfa_parametrized(
     expect_raises: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: connect behavior when _authn_check returns AUTH_NEEDS_MFA for initial True/False."""
+    """Connect handles `AUTH_NEEDS_MFA` consistently across initial and refresh paths."""
     client = RESTClient(config_na, session)
     client._cookie_dt = "cookie"
     client._access_token = None
@@ -467,7 +467,7 @@ async def test_connect_status_needs_mfa_parametrized(
 
 @pytest.mark.asyncio
 async def test_resmed_response_error_check_gql_query_not_initial_raises_parsing_error() -> None:
-    """Test that ParsingError is raised if step == 'gql_query' and not initial and unauthorized error."""
+    """Unauthorized GraphQL errors during refresh raise `ParsingError`."""
     # Prepare a fake response and error dict
     response = MagicMock(spec=ClientResponse)
     response.status = 401
@@ -484,7 +484,7 @@ async def test_resmed_response_error_check_gql_query_not_initial_raises_parsing_
 
 @pytest.mark.asyncio
 async def test_resmed_response_error_check_no_errors_key() -> None:
-    """Test _resmed_response_error_check does nothing if 'errors' not in resp_dict."""
+    """Responses without an `errors` key pass through the checker unchanged."""
     response = MagicMock(spec=ClientResponse)
     response.status = 200
     response.headers = {}
@@ -523,7 +523,7 @@ async def test_authn_check_raises_variants(
     match: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: _authn_check raises AuthenticationError for missing stateToken or sessionToken cases."""
+    """Auth payloads missing required tokens raise `AuthenticationError`."""
     client = RESTClient(config_na, session)
 
     mock_response = make_mock_aiohttp_response(json_value=json_value)
@@ -559,7 +559,7 @@ async def test_mfa_methods_success_variants(
     expected: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: covers _trigger_mfa and _verify_mfa success paths."""
+    """MFA trigger and verification helpers succeed on valid payloads."""
     client = RESTClient(config_na, session)
     client._state_token = "dummy_state_token"
     client._mfa_url = "https://example.com/mfa"
@@ -728,7 +728,7 @@ async def test_verify_mfa_raises_variants(
     match: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: Test _verify_mfa raises AuthenticationError for several failure responses."""
+    """Invalid MFA verification responses raise `AuthenticationError`."""
     client = RESTClient(config_na, session)
     client._state_token = "dummy_state_token"
     client._mfa_url = "https://example.com/mfa"
@@ -748,7 +748,7 @@ async def test_verify_mfa_raises_variants(
 async def test_get_access_token_success(
     config_na: MyAirConfig, session: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test _get_access_token sets tokens on success."""
+    """Successful token exchange stores the access and ID tokens."""
     client = RESTClient(config_na, session)
     client._session_token = "dummy_session_token"
     client._json_headers = {"Content-Type": "application/json"}
@@ -791,7 +791,7 @@ async def test_get_access_token_success(
 async def test_get_access_token_raises_on_missing_location(
     config_na: MyAirConfig, session: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test _get_access_token raises ParsingError if location header is missing."""
+    """Missing authorization redirect locations raise `ParsingError`."""
     client = RESTClient(config_na, session)
     client._session_token = "dummy_session_token"
     client._json_headers = {"Content-Type": "application/json"}
@@ -809,7 +809,7 @@ async def test_get_access_token_raises_on_missing_location(
 async def test_get_access_token_raises_on_missing_authorization_code(
     config_na: MyAirConfig, session: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test _get_access_token raises ParsingError if the redirect has no code."""
+    """Redirects without an authorization code raise `ParsingError`."""
     client = RESTClient(config_na, session)
     client._session_token = "dummy_session_token"
     client._json_headers = {"Content-Type": "application/json"}
@@ -848,7 +848,7 @@ async def test_get_access_token_raises_on_missing_token_variants(
     match_msg: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: Test _get_access_token raises ParsingError when token response lacks required keys."""
+    """Token responses missing required keys raise `ParsingError`."""
     client = RESTClient(config_na, session)
     client._session_token = "dummy_session_token"
     client._json_headers = {"Content-Type": "application/json"}
@@ -900,7 +900,7 @@ async def test_gql_query_variants(
     expected_country: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: gql_query success (extract country from id_token) and jwt decode error cases."""
+    """GraphQL queries decode country data and surface JWT failures."""
     client = RESTClient(config_na, session)
     client._access_token = "access"
     client._id_token = "idtoken"
@@ -926,6 +926,15 @@ async def test_gql_query_variants(
     else:
 
         def bad_decode(*a: object, **k: object) -> Never:
+            """Simulate a JWT decoder failure while preserving monkeypatch signature.
+
+            Args:
+                *a: Positional arguments passed by the GraphQL client.
+                **k: Keyword arguments passed by the GraphQL client.
+
+            Raises:
+                ValueError: Always raised to drive the parsing-error branch.
+            """
             raise ValueError("bad jwt")
 
         monkeypatch.setattr(
@@ -957,7 +966,7 @@ async def test_gql_query_failure_variants(
     match: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: _gql_query failure modes for JWT decoding, missing key, and missing id_token."""
+    """GraphQL query failures cover JWT decode, missing country, and missing ID token."""
     client = RESTClient(config_na, session)
     client._access_token = "access"
     client._id_token = id_token
@@ -968,6 +977,15 @@ async def test_gql_query_failure_variants(
         if "side_effect" in jwt_behavior:
 
             def side(*a: object, **k: object) -> Never:
+                """Raise the configured JWT decode error for this parameter set.
+
+                Args:
+                    *a: Positional arguments passed by the GraphQL client.
+                    **k: Keyword arguments passed by the GraphQL client.
+
+                Raises:
+                    Exception: The specific side effect supplied by the test case.
+                """
                 raise jwt_behavior["side_effect"]
 
             monkeypatch.setattr(
@@ -991,7 +1009,7 @@ async def test_gql_query_failure_variants(
 
 @pytest.mark.asyncio
 async def test_gql_query_graphql_error(config_na: MyAirConfig, session: MagicMock) -> None:
-    """Ensure gql_query maps GraphQL unauthorized errors."""
+    """GraphQL unauthorized responses map to `ParsingError`."""
     client = RESTClient(config_na, session)
     client._access_token = "access"
     client._id_token = None
@@ -1093,7 +1111,7 @@ async def test_data_fetch_success_variants(
     expected: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: success paths for data-fetching helpers (sleep records and device data)."""
+    """Data fetch helpers return typed models for sleep records and device data."""
     client = RESTClient(config_na, session)
     client._access_token = "access"
     client._country_code = "US"
@@ -1115,7 +1133,7 @@ async def test_data_fetch_success_variants(
 async def test_get_sleep_records_uses_local_date_range(
     config_na: MyAirConfig, session: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Ensure sleep record queries use the local date window."""
+    """Sleep-record queries use the local month window."""
 
     class FixedDateTime(datetime.datetime):
         """DateTime class with deterministic now() for query-window assertions."""
@@ -1157,7 +1175,7 @@ async def test_get_sleep_records_failure_variants(
     match_msg: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: get_sleep_records raises ParsingError for missing keys and non-list items."""
+    """Sleep-record fetches raise `ParsingError` for malformed payloads."""
     client = RESTClient(config_na, session)
     client._access_token = "access"
     client._country_code = "US"
@@ -1172,7 +1190,7 @@ async def test_get_sleep_records_raises_parsing_error_for_non_mapping_items(
     session: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Sleep record list entries must be mappings before model parsing."""
+    """Sleep-record list items must be mappings before model parsing."""
     client = RESTClient(config_na, session)
     mock_response = {"data": {"getPatientWrapper": {"sleepRecords": {"items": [123]}}}}
     monkeypatch.setattr(client, "_gql_query", AsyncMock(return_value=mock_response))
@@ -1199,7 +1217,7 @@ async def test_get_user_device_data_failure_variants(
     match_msg: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: get_user_device_data raises ParsingError for missing keys and invalid response types."""
+    """Device-data fetches raise `ParsingError` for malformed payloads."""
     client = RESTClient(config_na, session)
     client._access_token = "access"
     client._country_code = "US"
@@ -1226,7 +1244,7 @@ async def test_get_user_device_data_masks_variants(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Parametrized tests for masks behavior in get_user_device_data."""
+    """Device-data mask handling preserves valid masks and warns on misses."""
     client = RESTClient(config_na, session)
     client._access_token = "access"
     client._country_code = "US"
@@ -1264,7 +1282,7 @@ async def test_get_initial_dt_variants(
     expected_extract_arg: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized checks for _get_initial_dt with different cookie headers."""
+    """Initial DT extraction handles present and missing cookie headers."""
     client = RESTClient(config_na, session)
     mock_headers = MagicMock()
     mock_headers.getall = MagicMock(return_value=cookie_headers)
@@ -1281,7 +1299,7 @@ async def test_get_initial_dt_variants(
 
 @pytest.mark.asyncio
 async def test_resmed_response_error_check_not_bad_request() -> None:
-    """Test _resmed_response_error_check does NOT raise IncompleteAccountError if errorType is not 'badRequest' or errorCode not in set."""
+    """Non-matching response errors do not become incomplete-account failures."""
     # Prepare a fake response and error dict
     resp_dict = {
         "errors": [{"errorInfo": {"errorType": "someOtherType", "errorCode": "someOtherCode"}}]
@@ -1319,7 +1337,7 @@ async def test_resmed_response_error_check_not_bad_request() -> None:
 async def test_authn_check_email_factor_id_exceptions(
     authn_dict: object, session: MagicMock, config_na: MyAirConfig
 ) -> None:
-    """Test RESTClient._authn_check falls back to region_config['email_factor_id'] on KeyError/TypeError."""
+    """Auth checks fall back to the region email-factor ID on lookup errors."""
     # MyAirConfig is a NamedTuple (immutable) so use _replace to change device_token
     config = config_na._replace(device_token=None)
     client = RESTClient(config, session)
@@ -1351,7 +1369,7 @@ async def test_get_access_token_token_change_and_logging(
     expect_change: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized: test token equality vs new token and logging behavior for _get_access_token."""
+    """Token rotation logging distinguishes unchanged and updated access tokens."""
     # MyAirConfig is a NamedTuple (immutable) so create a modified copy
     config = config_na._replace(device_token=None)
     client = RESTClient(config, session)
@@ -1407,7 +1425,7 @@ async def test_status_helpers_variants(
     expected: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parametrized test covering small boolean helper methods that hit the auth endpoints."""
+    """Small auth endpoint helpers return the expected boolean states."""
     client = RESTClient(config_na, session)
     client._access_token = "token"
     mock_res = make_mock_aiohttp_response(json_value=response_json, headers={})
@@ -1434,7 +1452,7 @@ async def test_status_helpers_variants(
 async def test_resmed_response_error_check_parsing_variants(
     resp_dict: dict[str, object], expected_substring: object
 ) -> None:
-    """Parametrized: check various parsing fallbacks in _resmed_response_error_check."""
+    """Response-error parsing falls back cleanly across malformed payloads."""
     response = MagicMock(spec=ClientResponse)
     response.status = 400
     response.headers = CIMultiDict()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,4 +1,4 @@
-"""Unit tests for sensor entities in the resmed_myair integration."""
+"""Sensor-entity tests that protect availability and value translation."""
 
 import inspect
 import logging
@@ -41,7 +41,7 @@ def test_device_sensor_all_branches(
     monkeypatch: pytest.MonkeyPatch,
     coordinator_factory: CoordinatorFactory,
 ) -> None:
-    """Parametrized tests for MyAirDeviceSensor behavior across branches."""
+    """Device sensors honor key lookup, timestamp parsing, and availability."""
     # Construct description using the explicit device_class parameter so the test
     # deterministically controls whether the sensor is a timestamp sensor.
     if device_class is None:
@@ -72,7 +72,7 @@ def test_friendly_usage_time_all_branches(
     monkeypatch: pytest.MonkeyPatch,
     coordinator_factory: CoordinatorFactory,
 ) -> None:
-    """Parametrized tests for MyAirFriendlyUsageTime behavior across branches."""
+    """Friendly usage sensors format minutes and handle missing records."""
     coordinator = coordinator_factory(data=data)
     sensor = MyAirFriendlyUsageTime(coordinator)
     monkeypatch.setattr(sensor, "async_write_ha_state", MagicMock(return_value=None))
@@ -112,7 +112,7 @@ def test_most_recent_sleep_date_all_branches(
     monkeypatch: pytest.MonkeyPatch,
     coordinator_factory: CoordinatorFactory,
 ) -> None:
-    """Parametrized tests for MyAirMostRecentSleepDate behavior across branches."""
+    """Most-recent sleep date sensors select the latest usable record."""
     coordinator = coordinator_factory(data=data)
     sensor = MyAirMostRecentSleepDate(coordinator)
     monkeypatch.setattr(sensor, "async_write_ha_state", MagicMock(return_value=None))
@@ -143,7 +143,7 @@ def test_sleep_record_sensor_handle_coordinator_update(
     monkeypatch: pytest.MonkeyPatch,
     coordinator_factory: CoordinatorFactory,
 ) -> None:
-    """Parametrized tests for MyAirSleepRecordSensor handling various record formats."""
+    """Sleep-record sensors parse raw values and optional dates correctly."""
     # Patch dt_util.parse_date to return a sentinel for test
     if device_class == SensorDeviceClass.DATE:
         parsed_date = object()
@@ -169,7 +169,7 @@ def test_sleep_record_sensor_is_available_when_raw_key_value_is_none(
     monkeypatch: pytest.MonkeyPatch,
     coordinator_factory: CoordinatorFactory,
 ) -> None:
-    """Ensure raw sleep sensors stay available when the raw key exists with a null value."""
+    """Raw sleep-record keys with null values still count as available data."""
     coordinator = coordinator_factory(data={"sleep_records": [{"foo": None}]})
     sensor = MyAirSleepRecordSensor("Test", SensorEntityDescription(key="foo"), coordinator)
     monkeypatch.setattr(sensor, "async_write_ha_state", MagicMock(return_value=None))
@@ -226,7 +226,7 @@ def test_myair_device_sensor_parametrized(
     monkeypatch: pytest.MonkeyPatch,
     coordinator_factory: CoordinatorFactory,
 ) -> None:
-    """Combined parametrized test for MyAirDeviceSensor with optional datetime parsing."""
+    """Device sensors parse datetimes only when the entity class requires it."""
     # Patch dt_util.parse_datetime if needed
     if patch_parse_datetime:
         monkeypatch.setattr(
@@ -250,7 +250,7 @@ def test_device_sensor_is_available_when_raw_key_value_is_none(
     monkeypatch: pytest.MonkeyPatch,
     coordinator_factory: CoordinatorFactory,
 ) -> None:
-    """Ensure raw device sensors stay available when the raw key exists with a null value."""
+    """Raw device keys with null values still count as available data."""
     coordinator = coordinator_factory(data={"device": {"foo": None}})
     sensor = MyAirDeviceSensor("Test", SensorEntityDescription(key="foo"), coordinator)
     monkeypatch.setattr(sensor, "async_write_ha_state", MagicMock(return_value=None))
@@ -269,7 +269,7 @@ async def test_async_setup_entry_adds_entities_and_registers_service(
     config_entry: MockConfigEntry,
     service_registry_shim: ServiceRegistryShimLike,
 ) -> None:
-    """Test that async_setup_entry adds sensor entities and registers service."""
+    """Setup adds sensor entities and registers the force-poll service."""
     async_add_entities = MagicMock()
     coordinator = coordinator_factory(mock=True)
     # This test will create its own local MockConfigEntry (below) because
@@ -328,7 +328,7 @@ def test_myair_device_sensor_handle_coordinator_update_keyerror(
     coordinator_factory: CoordinatorFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Ensure MyAirDeviceSensor handles missing keys and logs an error."""
+    """Missing device keys leave the sensor unavailable and log the failure."""
     coordinator = coordinator_factory(mock=True)
     coordinator.data = coordinator_data(device={"serialNumber": "SN123"})
     desc = SensorEntityDescription(key="missing_key")


### PR DESCRIPTION
## Summary
Improves repo-wide docstrings for the ResMed myAir Home Assistant integration and its tests. This makes the integration contracts, auth/session state, sensor behavior, fixtures, and test invariants easier to understand without changing runtime behavior.

## What Changed
- Expanded integration, config-flow, coordinator, model, sensor, client, and auth docstrings with behavior-focused context and Google-style argument/return sections where useful
- Documented private helpers, property setters, nested service callbacks, test doubles, and fixtures that previously had missing or thin docstrings
- Clarified compatibility proxy modules and constants modules so their purpose is explicit
- Updated test docstrings to describe the behavior or invariant each test protects

## Why
The project guidelines require meaningful file, class, and method docstrings, including private and nested methods. This pass fills those gaps while keeping the Python AST unchanged after stripping docstrings, so the PR is documentation-only.

## Validation
- `./.venv/bin/prek run --all-files`
- `./.venv/bin/pytest` (`270 passed`)
