### PR TITLE
Add config flow reconfigure support

### DIFF
--- a/custom_components/resmed_myair/config_flow.py
+++ b/custom_components/resmed_myair/config_flow.py
@@ -244,6 +244,35 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="wrong_account")
         return None
 
+    async def _async_reconfigure_unique_id_update(
+        self, entry: ConfigEntry, device: MyAirDevice
+    ) -> str | None:
+        """Validate reconfigure device identity and return any unique ID update.
+
+        Args:
+            entry: Config entry being reconfigured.
+            device: Typed myAir device returned by the API.
+
+        Returns:
+            Device serial number when a legacy entry needs unique ID backfill,
+            otherwise `None`.
+
+        Raises:
+            ParsingError: When device data does not include a serial number.
+        """
+        if not device.serial_number:
+            raise ParsingError("Unable to get Serial Number from Device Data")
+        await self.async_set_unique_id(device.serial_number)
+        if not entry.unique_id:
+            _LOGGER.info(
+                "Reconfigure will backfill missing legacy entry unique ID with device serial "
+                "number %s",
+                device.serial_number,
+            )
+            return device.serial_number
+        self._abort_if_unique_id_mismatch(reason="wrong_account")
+        return None
+
     def _update_reload_and_abort(
         self,
         entry: ConfigEntry,
@@ -568,13 +597,14 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                     self._data.get(CONF_DEVICE_TOKEN, None),
                 )
                 if device and status == AUTHN_SUCCESS:
-                    if not device.serial_number:
-                        raise ParsingError("Unable to get Serial Number from Device Data")
-                    await self.async_set_unique_id(device.serial_number)
-                    self._abort_if_unique_id_mismatch(reason="wrong_account")
+                    unique_id = await self._async_reconfigure_unique_id_update(entry, device)
                     self._store_device_token()
                     _LOGGER.debug("[async_step_reconfigure] data: %s", redact_dict(self._data))
-                    return self._update_reload_and_abort(entry, data_updates={**self._data})
+                    return self._update_reload_and_abort(
+                        entry,
+                        data_updates={**self._data},
+                        unique_id=unique_id,
+                    )
                 return await self.async_step_reconfigure_verify_mfa()
             except (
                 AuthenticationError,
@@ -614,17 +644,18 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 status, device = await self._async_verify_mfa_and_get_device()
                 if status == AUTHN_SUCCESS:
-                    if not device.serial_number:
-                        raise ParsingError("Unable to get Serial Number from Device Data")
-                    await self.async_set_unique_id(device.serial_number)
-                    self._abort_if_unique_id_mismatch(reason="wrong_account")
+                    unique_id = await self._async_reconfigure_unique_id_update(entry, device)
                     self._data.pop(CONF_VERIFICATION_CODE, None)
                     self._store_device_token()
                     _LOGGER.debug(
                         "[async_step_reconfigure_verify_mfa] data: %s",
                         redact_dict(self._data),
                     )
-                    return self._update_reload_and_abort(entry, data_updates={**self._data})
+                    return self._update_reload_and_abort(
+                        entry,
+                        data_updates={**self._data},
+                        unique_id=unique_id,
+                    )
                 _LOGGER.error("Issue verifying MFA. Status: %s", status)
                 errors["base"] = "mfa_error"
             except (

--- a/custom_components/resmed_myair/config_flow.py
+++ b/custom_components/resmed_myair/config_flow.py
@@ -246,16 +246,16 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def _async_reconfigure_unique_id_update(
         self, entry: ConfigEntry, device: MyAirDevice
-    ) -> str | None:
-        """Validate reconfigure device identity and return any unique ID update.
+    ) -> tuple[ConfigFlowResult | None, str | None]:
+        """Validate reconfigure device identity and identify unique ID updates.
 
         Args:
             entry: Config entry being reconfigured.
             device: Typed myAir device returned by the API.
 
         Returns:
-            Device serial number when a legacy entry needs unique ID backfill,
-            otherwise `None`.
+            Abort result when reconfigure should stop, plus the device serial
+            number when a legacy entry needs unique ID backfill.
 
         Raises:
             ParsingError: When device data does not include a serial number.
@@ -269,9 +269,20 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                 "number %s",
                 device.serial_number,
             )
-            return device.serial_number
-        self._abort_if_unique_id_mismatch(reason="wrong_account")
-        return None
+            if self.hass.config_entries.async_entry_for_domain_unique_id(
+                self.handler,
+                device.serial_number,
+            ):
+                return self.async_abort(reason="already_configured"), None
+            return None, device.serial_number
+        if entry.unique_id != device.serial_number:
+            _LOGGER.error(
+                "Reconfigure device serial number %s does not match existing entry unique ID %s",
+                device.serial_number,
+                entry.unique_id,
+            )
+            return self.async_abort(reason="wrong_account"), None
+        return None, None
 
     def _update_reload_and_abort(
         self,
@@ -597,7 +608,11 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                     self._data.get(CONF_DEVICE_TOKEN, None),
                 )
                 if device and status == AUTHN_SUCCESS:
-                    unique_id = await self._async_reconfigure_unique_id_update(entry, device)
+                    identity_abort, unique_id = await self._async_reconfigure_unique_id_update(
+                        entry, device
+                    )
+                    if identity_abort:
+                        return identity_abort
                     self._store_device_token()
                     _LOGGER.debug("[async_step_reconfigure] data: %s", redact_dict(self._data))
                     return self._update_reload_and_abort(
@@ -644,7 +659,11 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 status, device = await self._async_verify_mfa_and_get_device()
                 if status == AUTHN_SUCCESS:
-                    unique_id = await self._async_reconfigure_unique_id_update(entry, device)
+                    identity_abort, unique_id = await self._async_reconfigure_unique_id_update(
+                        entry, device
+                    )
+                    if identity_abort:
+                        return identity_abort
                     self._data.pop(CONF_VERIFICATION_CODE, None)
                     self._store_device_token()
                     _LOGGER.debug(

--- a/custom_components/resmed_myair/config_flow.py
+++ b/custom_components/resmed_myair/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for resmed_myair."""
 
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 import logging
 from typing import Any
 
@@ -151,6 +151,56 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
         if self._client:
             self._data.update({CONF_DEVICE_TOKEN: self._client.device_token})
 
+    def _credentials_schema(
+        self, defaults: Mapping[str, Any] | None = None, *, include_region: bool
+    ) -> vol.Schema:
+        """Build the shared credential form schema.
+
+        Args:
+            defaults: Existing values to prefill in the form.
+            include_region: Whether the caller can change the myAir region.
+
+        Returns:
+            Voluptuous schema for Home Assistant's config-flow form.
+        """
+        defaults = defaults or {}
+        schema: dict[vol.Marker, object] = {
+            vol.Required(
+                CONF_USER_NAME, default=defaults.get(CONF_USER_NAME, None)
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+            ),
+            vol.Required(
+                CONF_PASSWORD, default=defaults.get(CONF_PASSWORD, None)
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+            ),
+        }
+        if include_region:
+            schema[vol.Required(CONF_REGION, default=defaults.get(CONF_REGION, REGION_NA))] = (
+                vol.In(
+                    {
+                        REGION_NA: "North America and Australia",
+                        REGION_EU: "Europe (Email MFA)",
+                    }
+                )
+            )
+        return vol.Schema(schema)
+
+    def _mfa_schema(self) -> vol.Schema:
+        """Build the shared MFA verification code schema.
+
+        Returns:
+            Voluptuous schema for Home Assistant's MFA form.
+        """
+        return vol.Schema(
+            {
+                vol.Required(CONF_VERIFICATION_CODE): selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+                ),
+            }
+        )
+
     def _entry_title(self, device: MyAirDevice) -> str:
         """Build a stable Home Assistant entry title from device metadata.
 
@@ -194,19 +244,27 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="wrong_account")
         return None
 
-    def _reauth_update_kwargs(self, device: MyAirDevice) -> dict[str, Any]:
-        """Build config-entry update arguments for a successful reauth.
+    def _update_reload_and_abort(
+        self,
+        entry: ConfigEntry,
+        *,
+        data_updates: Mapping[str, Any],
+        unique_id: str | None = None,
+    ) -> ConfigFlowResult:
+        """Update a config entry, schedule reload, and finish the flow.
 
         Args:
-            device: Typed myAir device returned by the API.
+            entry: Config entry being updated.
+            data_updates: Config-entry data values to merge into existing data.
+            unique_id: Optional unique ID to backfill on legacy entries.
 
         Returns:
-            Keyword arguments for Home Assistant's config-entry update helper.
+            Home Assistant config-flow abort result with source-specific reason.
         """
-        update_kwargs: dict[str, Any] = {"data": {**self._data}}
-        if not self._entry.unique_id:
-            update_kwargs["unique_id"] = device.serial_number
-        return update_kwargs
+        kwargs: dict[str, Any] = {"data_updates": data_updates}
+        if unique_id is not None:
+            kwargs["unique_id"] = unique_id
+        return self.async_update_reload_and_abort(entry, **kwargs)
 
     async def _async_abort_incomplete_account(
         self, step: str, error: IncompleteAccountError
@@ -293,22 +351,7 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
         _LOGGER.info("Setting up ResMed myAir Integration Version: %s", VERSION)
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_USER_NAME): selector.TextSelector(
-                        selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
-                    ),
-                    vol.Required(CONF_PASSWORD): selector.TextSelector(
-                        selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
-                    ),
-                    vol.Required(CONF_REGION, default=REGION_NA): vol.In(
-                        {
-                            REGION_NA: "North America and Australia",
-                            REGION_EU: "Europe (Email MFA)",
-                        }
-                    ),
-                }
-            ),
+            data_schema=self._credentials_schema(include_region=True),
             errors=errors,
         )
 
@@ -360,13 +403,7 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
         _LOGGER.info("Showing Verify MFA Form")
         return self.async_show_form(
             step_id="verify_mfa",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_VERIFICATION_CODE): selector.TextSelector(
-                        selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
-                    ),
-                }
-            ),
+            data_schema=self._mfa_schema(),
             description_placeholders={
                 "username": self._data.get(CONF_USER_NAME, "your email address"),
             },
@@ -386,12 +423,11 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
             UnknownEntry: When Home Assistant no longer has the reauth entry.
         """
         _LOGGER.info("Starting Reauthorization")
-        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
-        if entry:
-            self._entry = entry
-        else:
+        try:
+            self._entry = self._get_reauth_entry()
+        except UnknownEntry:
             _LOGGER.error("No entry found for reauthorization")
-            raise UnknownEntry(self.context["entry_id"])
+            raise
         _LOGGER.debug("[async_step_reauth] entry: %s", redact_dict(self._entry))
         _LOGGER.debug("[async_step_reauth] entry_data: %s", redact_dict(entry_data))
         self._data.update(entry_data)
@@ -425,11 +461,12 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                     self._store_device_token()
                     _LOGGER.debug("[async_step_reauth_confirm] data: %s", redact_dict(self._data))
 
-                    self.hass.config_entries.async_update_entry(
-                        self._entry, **self._reauth_update_kwargs(device)
+                    unique_id = device.serial_number if not self._entry.unique_id else None
+                    return self._update_reload_and_abort(
+                        self._entry,
+                        data_updates={**self._data},
+                        unique_id=unique_id,
                     )
-                    await self.hass.config_entries.async_reload(self._entry.entry_id)
-                    return self.async_abort(reason="reauth_successful")
                 return await self.async_step_reauth_verify_mfa()
             except (
                 AuthenticationError,
@@ -446,20 +483,7 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
         _LOGGER.info("Showing Reauth Confirm Form")
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_USER_NAME, default=self._data.get(CONF_USER_NAME, None)
-                    ): selector.TextSelector(
-                        selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
-                    ),
-                    vol.Required(
-                        CONF_PASSWORD, default=self._data.get(CONF_PASSWORD, None)
-                    ): selector.TextSelector(
-                        selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
-                    ),
-                }
-            ),
+            data_schema=self._credentials_schema(self._data, include_region=False),
             errors=errors,
         )
 
@@ -491,11 +515,12 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                         "[async_step_reauth_verify_mfa] user_input: %s", redact_dict(self._data)
                     )
 
-                    self.hass.config_entries.async_update_entry(
-                        self._entry, **self._reauth_update_kwargs(device)
+                    unique_id = device.serial_number if not self._entry.unique_id else None
+                    return self._update_reload_and_abort(
+                        self._entry,
+                        data_updates={**self._data},
+                        unique_id=unique_id,
                     )
-                    await self.hass.config_entries.async_reload(self._entry.entry_id)
-                    return self.async_abort(reason="reauth_successful")
                 _LOGGER.error("Issue verifying MFA. Status: %s", status)
                 errors["base"] = "mfa_error"
             except (
@@ -512,13 +537,115 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
         _LOGGER.info("Showing Reauth Verify MFA Form")
         return self.async_show_form(
             step_id="reauth_verify_mfa",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_VERIFICATION_CODE): selector.TextSelector(
-                        selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
-                    ),
-                }
-            ),
+            data_schema=self._mfa_schema(),
+            description_placeholders={
+                "username": self._data.get(CONF_USER_NAME, "your email address"),
+            },
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: MutableMapping[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Collect updated setup data and validate it against the same device.
+
+        Args:
+            user_input: Submitted username, password, and region values.
+
+        Returns:
+            Reconfigure form, MFA step, abort, or successful update result.
+        """
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+
+        if not self._data:
+            self._data.update(entry.data)
+
+        if user_input:
+            self._data.update(user_input)
+            try:
+                status, device = await self._async_login_and_get_device(
+                    self._data.get(CONF_DEVICE_TOKEN, None),
+                )
+                if device and status == AUTHN_SUCCESS:
+                    if not device.serial_number:
+                        raise ParsingError("Unable to get Serial Number from Device Data")
+                    await self.async_set_unique_id(device.serial_number)
+                    self._abort_if_unique_id_mismatch(reason="wrong_account")
+                    self._store_device_token()
+                    _LOGGER.debug("[async_step_reconfigure] data: %s", redact_dict(self._data))
+                    return self._update_reload_and_abort(entry, data_updates={**self._data})
+                return await self.async_step_reconfigure_verify_mfa()
+            except (
+                AuthenticationError,
+                HttpProcessingError,
+                ClientResponseError,
+                ParsingError,
+            ) as e:
+                _LOGGER.error("Connection Error at reconfigure. %s: %s", type(e).__name__, e)
+                errors["base"] = "authentication_error"
+            except IncompleteAccountError as e:
+                return await self._async_abort_incomplete_account("reconfigure", e)
+
+        _LOGGER.info("Showing Reconfigure Form")
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self._credentials_schema(self._data, include_region=True),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure_verify_mfa(
+        self, user_input: MutableMapping[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Complete MFA during reconfigure and reload the updated config entry.
+
+        Args:
+            user_input: Submitted verification code from the reconfigure MFA form.
+
+        Returns:
+            Reconfigure MFA form, abort, or successful update result.
+        """
+        errors: dict[str, str] = {}
+        user_input = user_input or {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input and isinstance(self._client, RESTClient):
+            self._data.update(user_input)
+            try:
+                status, device = await self._async_verify_mfa_and_get_device()
+                if status == AUTHN_SUCCESS:
+                    if not device.serial_number:
+                        raise ParsingError("Unable to get Serial Number from Device Data")
+                    await self.async_set_unique_id(device.serial_number)
+                    self._abort_if_unique_id_mismatch(reason="wrong_account")
+                    self._data.pop(CONF_VERIFICATION_CODE, None)
+                    self._store_device_token()
+                    _LOGGER.debug(
+                        "[async_step_reconfigure_verify_mfa] data: %s",
+                        redact_dict(self._data),
+                    )
+                    return self._update_reload_and_abort(entry, data_updates={**self._data})
+                _LOGGER.error("Issue verifying MFA. Status: %s", status)
+                errors["base"] = "mfa_error"
+            except (
+                AuthenticationError,
+                HttpProcessingError,
+                ClientResponseError,
+                ParsingError,
+            ) as e:
+                _LOGGER.error(
+                    "Connection Error at reconfigure_verify_mfa. %s: %s",
+                    type(e).__name__,
+                    e,
+                )
+                errors["base"] = "mfa_error"
+            except IncompleteAccountError as e:
+                return await self._async_abort_incomplete_account("reconfigure_verify_mfa", e)
+
+        _LOGGER.info("Showing Reconfigure Verify MFA Form")
+        return self.async_show_form(
+            step_id="reconfigure_verify_mfa",
+            data_schema=self._mfa_schema(),
             description_placeholders={
                 "username": self._data.get(CONF_USER_NAME, "your email address"),
             },

--- a/custom_components/resmed_myair/translations/de.json
+++ b/custom_components/resmed_myair/translations/de.json
@@ -1,0 +1,66 @@
+{
+    "title": "ResMed myAir CPAP-Sensoren",
+    "config": {
+        "step": {
+            "user": {
+                "title": "ResMed myAir-Anmeldedaten",
+                "data": {
+                    "Username": "Benutzername",
+                    "Password": "Passwort",
+                    "Region": "myAir-Region"
+                },
+                "description": "Gib den Benutzernamen und das Passwort ein, die du in der myAir-App oder auf der myAir-Website verwendest."
+            },
+            "verify_mfa": {
+                "title": "MFA bestätigen",
+                "data": {
+                    "verification_code": "Einmaliger Bestätigungscode"
+                },
+                "description": "Gib den einmaligen Bestätigungscode ein, den du von ResMed für {username} erhalten hast."
+            },
+            "reauth_confirm": {
+                "title": "ResMed myAir erneut authentifizieren",
+                "description": "Die ResMed myAir-Integration muss dein Konto erneut authentifizieren",
+                "data": {
+                    "Username": "Benutzername",
+                    "Password": "Passwort"
+                }
+            },
+            "reauth_verify_mfa": {
+                "title": "MFA bestätigen",
+                "data": {
+                    "verification_code": "Einmaliger Bestätigungscode"
+                },
+                "description": "Gib den einmaligen Bestätigungscode ein, den du von ResMed für {username} erhalten hast."
+            },
+            "reconfigure": {
+                "title": "ResMed myAir neu konfigurieren",
+                "description": "Aktualisiere die Kontodaten, die von der ResMed myAir-Integration verwendet werden.",
+                "data": {
+                    "Username": "Benutzername",
+                    "Password": "Passwort",
+                    "Region": "myAir-Region"
+                }
+            },
+            "reconfigure_verify_mfa": {
+                "title": "MFA bestätigen",
+                "data": {
+                    "verification_code": "Einmaliger Bestätigungscode"
+                },
+                "description": "Gib den einmaligen Bestätigungscode ein, den du von ResMed für {username} erhalten hast."
+            }
+        },
+        "error": {
+            "authentication_error": "Ungültiger Benutzername oder ungültiges Passwort. Bitte prüfe die Angaben auf myair.resmed.com",
+            "mfa_error": "MFA konnte nicht bestätigt werden. Stelle sicher, dass der Code korrekt ist."
+        },
+        "abort": {
+            "already_configured": "Das Gerät ist bereits konfiguriert",
+            "incomplete_account": "Die Einrichtung des ResMed myAir-Kontos ist unvollständig. Melde dich auf der myAir-Website an und stelle sicher, dass CPAP-Daten angezeigt werden. Stelle außerdem sicher, dass unter Mein Konto die Zeitzone festgelegt ist.",
+            "incomplete_account_verify_email": "Die Einrichtung des ResMed myAir-Kontos ist unvollständig. Die E-Mail-Adresse wurde nicht bestätigt.",
+            "reauth_successful": "ResMed myAir wurde erfolgreich erneut authentifiziert",
+            "reconfigure_successful": "ResMed myAir wurde erfolgreich neu konfiguriert",
+            "wrong_account": "Das Konto gehört zu einem anderen Gerät. Verwende die Anmeldedaten für das ursprünglich konfigurierte Gerät."
+        }
+    }
+}

--- a/custom_components/resmed_myair/translations/en.json
+++ b/custom_components/resmed_myair/translations/en.json
@@ -32,6 +32,22 @@
                     "verification_code": "One-time verification code"
                 },
                 "description": "Enter the One-time verification code you received from ResMed to {username}."
+            },
+            "reconfigure": {
+                "title": "Reconfigure ResMed myAir",
+                "description": "Update the account details used by the ResMed myAir integration.",
+                "data": {
+                    "Username": "Username",
+                    "Password": "Password",
+                    "Region": "myAir Region"
+                }
+            },
+            "reconfigure_verify_mfa": {
+                "title": "Verify MFA",
+                "data": {
+                    "verification_code": "One-time verification code"
+                },
+                "description": "Enter the One-time verification code you received from ResMed to {username}."
             }
         },
         "error": {
@@ -43,7 +59,8 @@
             "incomplete_account": "ResMed myAir Account Setup is Incomplete. Login to the myAir website and ensure that CPAP data is showing. Also, ensure that the Time Zone is set under My Account.",
             "incomplete_account_verify_email": "ResMed myAir Account Setup is Incomplete. Email address has not been verified.",
             "reauth_successful": "ResMed myAir Reauthentication Successful",
-            "wrong_account": "Reauthentication failed because the account belongs to a different device. Use credentials for the originally configured device."
+            "reconfigure_successful": "ResMed myAir Reconfiguration Successful",
+            "wrong_account": "The account belongs to a different device. Use credentials for the originally configured device."
         }
     }
 }

--- a/custom_components/resmed_myair/translations/es.json
+++ b/custom_components/resmed_myair/translations/es.json
@@ -1,0 +1,66 @@
+{
+    "title": "Sensores CPAP de ResMed myAir",
+    "config": {
+        "step": {
+            "user": {
+                "title": "Información de inicio de sesión de ResMed myAir",
+                "data": {
+                    "Username": "Usuario",
+                    "Password": "Contraseña",
+                    "Region": "Región de myAir"
+                },
+                "description": "Introduce el usuario y la contraseña que usas en la aplicación o el sitio web de myAir."
+            },
+            "verify_mfa": {
+                "title": "Verificar MFA",
+                "data": {
+                    "verification_code": "Código de verificación de un solo uso"
+                },
+                "description": "Introduce el código de verificación de un solo uso que recibiste de ResMed para {username}."
+            },
+            "reauth_confirm": {
+                "title": "Reautenticación de ResMed myAir",
+                "description": "La integración ResMed myAir necesita volver a autenticar tu cuenta",
+                "data": {
+                    "Username": "Usuario",
+                    "Password": "Contraseña"
+                }
+            },
+            "reauth_verify_mfa": {
+                "title": "Verificar MFA",
+                "data": {
+                    "verification_code": "Código de verificación de un solo uso"
+                },
+                "description": "Introduce el código de verificación de un solo uso que recibiste de ResMed para {username}."
+            },
+            "reconfigure": {
+                "title": "Reconfigurar ResMed myAir",
+                "description": "Actualiza los datos de la cuenta que usa la integración ResMed myAir.",
+                "data": {
+                    "Username": "Usuario",
+                    "Password": "Contraseña",
+                    "Region": "Región de myAir"
+                }
+            },
+            "reconfigure_verify_mfa": {
+                "title": "Verificar MFA",
+                "data": {
+                    "verification_code": "Código de verificación de un solo uso"
+                },
+                "description": "Introduce el código de verificación de un solo uso que recibiste de ResMed para {username}."
+            }
+        },
+        "error": {
+            "authentication_error": "Usuario o contraseña no válidos. Verifícalos en myair.resmed.com",
+            "mfa_error": "No se pudo verificar MFA. Asegúrate de que el código sea correcto."
+        },
+        "abort": {
+            "already_configured": "El dispositivo ya está configurado",
+            "incomplete_account": "La configuración de la cuenta de ResMed myAir está incompleta. Inicia sesión en el sitio web de myAir y asegúrate de que se muestren los datos de CPAP. Además, asegúrate de que la zona horaria esté configurada en Mi cuenta.",
+            "incomplete_account_verify_email": "La configuración de la cuenta de ResMed myAir está incompleta. La dirección de correo electrónico no se ha verificado.",
+            "reauth_successful": "Reautenticación de ResMed myAir correcta",
+            "reconfigure_successful": "Reconfiguración de ResMed myAir correcta",
+            "wrong_account": "La cuenta pertenece a un dispositivo diferente. Usa las credenciales del dispositivo configurado originalmente."
+        }
+    }
+}

--- a/custom_components/resmed_myair/translations/fr.json
+++ b/custom_components/resmed_myair/translations/fr.json
@@ -32,6 +32,22 @@
                     "verification_code": "Code de vérification à usage unique"
                 },
                 "description": "Entrez le code de vérification à usage unique que vous avez reçu de ResMed pour {username}."
+            },
+            "reconfigure": {
+                "title": "Reconfigurer ResMed myAir",
+                "description": "Mettez à jour les informations du compte utilisées par l’intégration ResMed myAir.",
+                "data": {
+                    "Username": "Utilisateur",
+                    "Password": "Mot de passe",
+                    "Region": "Région myAir"
+                }
+            },
+            "reconfigure_verify_mfa": {
+                "title": "Vérifier le MFA",
+                "data": {
+                    "verification_code": "Code de vérification à usage unique"
+                },
+                "description": "Entrez le code de vérification à usage unique que vous avez reçu de ResMed pour {username}."
             }
         },
         "error": {
@@ -43,7 +59,8 @@
             "incomplete_account": "La configuration du compte ResMed myAir est incomplète. Connectez-vous au site web myAir et assurez-vous que les données du CPAP s’affichent. Vérifiez également que le fuseau horaire est défini dans Mon compte.",
             "incomplete_account_verify_email": "La configuration du compte ResMed myAir est incomplète. L’adresse e-mail n’a pas été vérifiée.",
             "reauth_successful": "Réauthentification ResMed myAir réussie",
-            "wrong_account": "La réauthentification a échoué, car le compte appartient à un autre appareil. Utilisez les identifiants de l’appareil configuré à l’origine."
+            "reconfigure_successful": "Reconfiguration ResMed myAir réussie",
+            "wrong_account": "Le compte appartient à un autre appareil. Utilisez les identifiants de l’appareil configuré à l’origine."
         }
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ convention = "google"
 
 [tool.codespell]
 ignore-words-list = "hass"
-skip = "custom_components/resmed_myair/translations/fr.json"
+skip = "custom_components/resmed_myair/translations/de.json,custom_components/resmed_myair/translations/es.json,custom_components/resmed_myair/translations/fr.json"
 
 
 [tool.pytest.ini_options]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -760,6 +760,7 @@ async def test_async_step_reconfigure_backfills_legacy_entry_unique_id(
     flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
     flow._client = myair_client
     flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
+    flow.hass.config_entries.async_entry_for_domain_unique_id = MagicMock(return_value=None)
     flow.hass.config_entries.async_schedule_reload = MagicMock()
     myair_client.device_token = "updated-token"
     if step_name == "async_step_reconfigure_verify_mfa":
@@ -797,6 +798,230 @@ async def test_async_step_reconfigure_backfills_legacy_entry_unique_id(
     }
     assert kwargs["unique_id"] == "SN123"
     flow.hass.config_entries.async_schedule_reload.assert_called_once_with("mock_entry_id")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("step_name", "helper_name", "user_input"),
+    [
+        (
+            "async_step_reconfigure",
+            "get_device",
+            {
+                CONF_USER_NAME: "new@example.com",
+                CONF_PASSWORD: "new-password",
+                CONF_REGION: REGION_EU,
+            },
+        ),
+        (
+            "async_step_reconfigure_verify_mfa",
+            "get_mfa_device",
+            {CONF_VERIFICATION_CODE: "654321"},
+        ),
+    ],
+)
+async def test_async_step_reconfigure_aborts_on_unverified_device_identity(
+    flow: MyAirConfigFlow,
+    myair_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    step_name: str,
+    helper_name: str,
+    user_input: dict[str, str],
+) -> None:
+    """Reconfigure refuses to update an entry when device identity changes."""
+    config_entry = MockConfigEntry(
+        domain="resmed_myair",
+        title="ResMed-CPAP",
+        data={
+            CONF_USER_NAME: "old@example.com",
+            CONF_PASSWORD: "old-password",
+            CONF_REGION: REGION_NA,
+            CONF_DEVICE_TOKEN: "old-token",
+        },
+        entry_id="mock_entry_id",
+        unique_id="SN123",
+        version=2,
+    )
+    flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
+    flow._client = myair_client
+    flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
+    if step_name == "async_step_reconfigure_verify_mfa":
+        flow._data = {
+            CONF_USER_NAME: "new@example.com",
+            CONF_PASSWORD: "new-password",
+            CONF_REGION: REGION_EU,
+            CONF_DEVICE_TOKEN: "old-token",
+        }
+    mismatched_device = MyAirDevice.from_api(
+        {
+            "serialNumber": "SN999",
+            "fgDeviceManufacturerName": "ResMed",
+            "localizedName": "Guest CPAP",
+        }
+    )
+    helper_result = (
+        (AUTHN_SUCCESS, mismatched_device, myair_client)
+        if helper_name == "get_device"
+        else (AUTHN_SUCCESS, mismatched_device)
+    )
+    monkeypatch.setattr(config_flow, helper_name, AsyncMock(return_value=helper_result))
+
+    result = await getattr(flow, step_name)(user_input)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "wrong_account"
+    flow.hass.config_entries.async_update_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_step_reconfigure_legacy_backfill_aborts_on_duplicate_unique_id(
+    flow: MyAirConfigFlow,
+    myair_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy reconfigure refuses to backfill a serial used by another entry."""
+    legacy_entry = MockConfigEntry(
+        domain="resmed_myair",
+        title="Legacy ResMed-CPAP",
+        data={
+            CONF_USER_NAME: "old@example.com",
+            CONF_PASSWORD: "old-password",
+            CONF_REGION: REGION_NA,
+            CONF_DEVICE_TOKEN: "old-token",
+        },
+        entry_id="legacy_entry",
+        unique_id=None,
+        version=2,
+    )
+    existing_entry = MockConfigEntry(
+        domain="resmed_myair",
+        title="Existing ResMed-CPAP",
+        data={CONF_USER_NAME: "existing@example.com"},
+        entry_id="existing_entry",
+        unique_id="SN123",
+        version=2,
+    )
+    flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": legacy_entry.entry_id}
+    flow._client = myair_client
+    flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=legacy_entry)
+    flow.hass.config_entries.async_entry_for_domain_unique_id = MagicMock(
+        return_value=existing_entry
+    )
+    myair_client.device_token = "updated-token"
+    device = MyAirDevice.from_api(
+        {
+            "serialNumber": "SN123",
+            "fgDeviceManufacturerName": "ResMed",
+            "localizedName": "CPAP",
+        }
+    )
+    monkeypatch.setattr(
+        config_flow,
+        "get_device",
+        AsyncMock(return_value=(AUTHN_SUCCESS, device, myair_client)),
+    )
+
+    result = await flow.async_step_reconfigure(
+        {
+            CONF_USER_NAME: "new@example.com",
+            CONF_PASSWORD: "new-password",
+            CONF_REGION: REGION_EU,
+        }
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    flow.hass.config_entries.async_update_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("step_name", "helper_name", "user_input", "is_email_verified", "expected_abort_reason"),
+    [
+        (
+            "async_step_reconfigure",
+            "get_device",
+            {
+                CONF_USER_NAME: "new@example.com",
+                CONF_PASSWORD: "new-password",
+                CONF_REGION: REGION_EU,
+            },
+            False,
+            "incomplete_account_verify_email",
+        ),
+        (
+            "async_step_reconfigure",
+            "get_device",
+            {
+                CONF_USER_NAME: "new@example.com",
+                CONF_PASSWORD: "new-password",
+                CONF_REGION: REGION_EU,
+            },
+            True,
+            "incomplete_account",
+        ),
+        (
+            "async_step_reconfigure_verify_mfa",
+            "get_mfa_device",
+            {CONF_VERIFICATION_CODE: "654321"},
+            False,
+            "incomplete_account_verify_email",
+        ),
+        (
+            "async_step_reconfigure_verify_mfa",
+            "get_mfa_device",
+            {CONF_VERIFICATION_CODE: "654321"},
+            True,
+            "incomplete_account",
+        ),
+    ],
+)
+async def test_async_step_reconfigure_incomplete_account_abort_variants(
+    flow: MyAirConfigFlow,
+    myair_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    step_name: str,
+    helper_name: str,
+    user_input: dict[str, str],
+    is_email_verified: bool,
+    expected_abort_reason: str,
+) -> None:
+    """Reconfigure steps preserve incomplete-account abort handling."""
+    config_entry = MockConfigEntry(
+        domain="resmed_myair",
+        title="ResMed-CPAP",
+        data={
+            CONF_USER_NAME: "old@example.com",
+            CONF_PASSWORD: "old-password",
+            CONF_REGION: REGION_NA,
+            CONF_DEVICE_TOKEN: "old-token",
+        },
+        entry_id="mock_entry_id",
+        unique_id="SN123",
+        version=2,
+    )
+    flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
+    flow._client = myair_client
+    flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
+    flow._client.is_email_verified = AsyncMock(return_value=is_email_verified)
+    if step_name == "async_step_reconfigure_verify_mfa":
+        flow._data = {
+            CONF_USER_NAME: "new@example.com",
+            CONF_PASSWORD: "new-password",
+            CONF_REGION: REGION_EU,
+            CONF_DEVICE_TOKEN: "old-token",
+        }
+    monkeypatch.setattr(
+        config_flow,
+        helper_name,
+        AsyncMock(side_effect=IncompleteAccountError("incomplete")),
+    )
+
+    result = await getattr(flow, step_name)(user_input)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == expected_abort_reason
+    flow._client.is_email_verified.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 from aiohttp import ClientError
-from homeassistant.config_entries import UnknownEntry
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_RECONFIGURE, UnknownEntry
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -18,6 +18,7 @@ from custom_components.resmed_myair.config_flow import (
     CONF_REGION,
     CONF_USER_NAME,
     CONF_VERIFICATION_CODE,
+    REGION_EU,
     REGION_NA,
     AuthenticationError,
     HttpProcessingError,
@@ -36,6 +37,7 @@ CONFIG_FLOW_ABORT_REASONS = (
     "incomplete_account",
     "incomplete_account_verify_email",
     "reauth_successful",
+    "reconfigure_successful",
     "wrong_account",
 )
 
@@ -308,6 +310,7 @@ async def test_async_step_reauth_backfills_legacy_entry_unique_id(
     )
     flow._entry = config_entry
     flow._client = myair_client
+    flow.hass.config_entries.async_schedule_reload = MagicMock()
     myair_client.device_token = "updated-token"
     flow._data = {CONF_USER_NAME: "user", CONF_PASSWORD: "pass", CONF_REGION: REGION_NA}
     device = MyAirDevice.from_api(
@@ -328,17 +331,16 @@ async def test_async_step_reauth_backfills_legacy_entry_unique_id(
 
     assert result["type"] == "abort"
     assert result["reason"] == "reauth_successful"
-    flow.hass.config_entries.async_update_entry.assert_called_once_with(
-        config_entry,
-        data={
-            CONF_USER_NAME: "user",
-            CONF_PASSWORD: "pass",
-            CONF_REGION: REGION_NA,
-            CONF_DEVICE_TOKEN: "updated-token",
-        },
-        unique_id="SN123",
-    )
-    flow.hass.config_entries.async_reload.assert_awaited_once_with("mock_entry_id")
+    _, kwargs = flow.hass.config_entries.async_update_entry.call_args
+    assert kwargs["entry"] is config_entry
+    assert kwargs["data"] == {
+        CONF_USER_NAME: "user",
+        CONF_PASSWORD: "pass",
+        CONF_REGION: REGION_NA,
+        CONF_DEVICE_TOKEN: "updated-token",
+    }
+    assert kwargs["unique_id"] == "SN123"
+    flow.hass.config_entries.async_schedule_reload.assert_called_once_with("mock_entry_id")
 
 
 @pytest.mark.asyncio
@@ -628,9 +630,9 @@ async def test_async_step_reauth_calls_confirm(
     """The reauth entry route loads entry data before calling confirm."""
     flow = MyAirConfigFlow()
     flow.hass = hass
-    flow.context = {"entry_id": "123"}
+    flow.context = {"source": SOURCE_REAUTH, "entry_id": "123"}
     flow._data = {}
-    flow.hass.config_entries.async_get_entry = MagicMock(return_value=config_entry)
+    flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
 
     flow.async_step_reauth_confirm = AsyncMock(return_value={"type": "form"})
     entry_data = {"foo": "bar"}
@@ -640,7 +642,77 @@ async def test_async_step_reauth_calls_confirm(
     assert flow._entry == config_entry
     assert flow._data["foo"] == "bar"
     flow.async_step_reauth_confirm.assert_awaited_once()
-    flow.hass.config_entries.async_get_entry.assert_called_once_with("123")
+    flow.hass.config_entries.async_get_known_entry.assert_called_once_with("123")
+
+
+@pytest.mark.asyncio
+async def test_async_step_reconfigure_success_updates_entry_and_schedules_reload(
+    hass: MagicMock,
+    myair_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconfigure validates the same device before updating setup data."""
+    config_entry = MockConfigEntry(
+        domain="resmed_myair",
+        title="ResMed-CPAP",
+        data={
+            CONF_USER_NAME: "old@example.com",
+            CONF_PASSWORD: "old-password",
+            CONF_REGION: REGION_NA,
+            CONF_DEVICE_TOKEN: "old-token",
+        },
+        entry_id="mock_entry_id",
+        unique_id="SN123",
+        version=2,
+    )
+    device = MyAirDevice.from_api(
+        {
+            "serialNumber": "SN123",
+            "fgDeviceManufacturerName": "ResMed",
+            "localizedName": "CPAP",
+        }
+    )
+    myair_client.device_token = "new-token"
+    monkeypatch.setattr(
+        config_flow,
+        "get_device",
+        AsyncMock(return_value=(AUTHN_SUCCESS, device, myair_client)),
+    )
+    hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
+    hass.config_entries.async_schedule_reload = MagicMock()
+    flow = MyAirConfigFlow()
+    flow.hass = hass
+    flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
+
+    result = await flow.async_step_reconfigure(
+        {
+            CONF_USER_NAME: "new@example.com",
+            CONF_PASSWORD: "new-password",
+            CONF_REGION: REGION_EU,
+        }
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reconfigure_successful"
+    get_device_mock = config_flow.get_device
+    assert isinstance(get_device_mock, AsyncMock)
+    get_device_mock.assert_awaited_once_with(
+        hass,
+        "new@example.com",
+        "new-password",
+        REGION_EU,
+        "old-token",
+    )
+    hass.config_entries.async_get_known_entry.assert_any_call("mock_entry_id")
+    _, kwargs = hass.config_entries.async_update_entry.call_args
+    assert kwargs["entry"] is config_entry
+    assert kwargs["data"] == {
+        CONF_USER_NAME: "new@example.com",
+        CONF_PASSWORD: "new-password",
+        CONF_REGION: REGION_EU,
+        CONF_DEVICE_TOKEN: "new-token",
+    }
+    hass.config_entries.async_schedule_reload.assert_called_once_with("mock_entry_id")
 
 
 @pytest.mark.asyncio
@@ -710,12 +782,14 @@ async def test_async_step_reauth_no_entry(hass: MagicMock) -> None:
     """Reauth aborts when the referenced config entry no longer exists."""
     flow = MyAirConfigFlow()
     flow.hass = hass
-    flow.hass.config_entries.async_get_entry.return_value = None
-    flow.context = {"entry_id": "missing_entry"}
+    flow.hass.config_entries.async_get_known_entry = MagicMock(
+        side_effect=UnknownEntry("missing_entry")
+    )
+    flow.context = {"source": SOURCE_REAUTH, "entry_id": "missing_entry"}
 
     with pytest.raises(UnknownEntry):
         await flow.async_step_reauth({})
-    flow.hass.config_entries.async_get_entry.assert_called_once_with("missing_entry")
+    flow.hass.config_entries.async_get_known_entry.assert_called_once_with("missing_entry")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -144,12 +144,15 @@ async def test_async_step_verify_mfa_error(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("step_name", "pre_setup", "expected_step_id"),
+    ("step_name", "pre_setup", "expected_step_id", "source"),
     [
-        ("async_step_user", False, "user"),
-        ("async_step_verify_mfa", True, "verify_mfa"),
-        ("async_step_reauth_confirm", True, "reauth_confirm"),
-        ("async_step_reauth_verify_mfa", True, "reauth_verify_mfa"),
+        ("async_step_user", False, "user", None),
+        ("async_step_verify_mfa", True, "verify_mfa", None),
+        ("async_step_reauth_confirm", True, "reauth_confirm", None),
+        ("async_step_reauth_verify_mfa", True, "reauth_verify_mfa", None),
+        ("async_step_reconfigure", False, "reconfigure", SOURCE_RECONFIGURE),
+        ("async_step_reconfigure", True, "reconfigure", SOURCE_RECONFIGURE),
+        ("async_step_reconfigure_verify_mfa", True, "reconfigure_verify_mfa", SOURCE_RECONFIGURE),
     ],
 )
 async def test_async_step_forms_display_parametrized(
@@ -157,9 +160,14 @@ async def test_async_step_forms_display_parametrized(
     step_name: str,
     pre_setup: bool,
     expected_step_id: str,
+    source: str | None,
     myair_client: MagicMock,
+    config_entry: MockConfigEntry,
 ) -> None:
     """User and MFA steps both render their forms when called without input."""
+    if source == SOURCE_RECONFIGURE:
+        flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
+        flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
     if pre_setup:
         flow._client = myair_client
         flow._data = {CONF_USER_NAME: "user", CONF_PASSWORD: "pass"}
@@ -168,6 +176,22 @@ async def test_async_step_forms_display_parametrized(
     assert result["type"] == "form"
     assert result["step_id"] == expected_step_id
     assert "errors" in result
+
+
+@pytest.mark.asyncio
+async def test_config_flow_private_auth_helpers_handle_missing_state(
+    flow: MyAirConfigFlow,
+) -> None:
+    """Auth helper methods handle missing transient client state safely."""
+    flow._client = None
+    flow._data = {}
+
+    with pytest.raises(AuthenticationError):
+        await flow._async_verify_mfa_and_get_device()
+
+    flow._store_device_token()
+
+    assert CONF_DEVICE_TOKEN not in flow._data
 
 
 @pytest.mark.asyncio
@@ -592,22 +616,28 @@ async def test_get_device_passes_device_token(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("step_name", "expected_step_id"),
+    ("step_name", "expected_step_id", "source"),
     [
-        ("async_step_verify_mfa", "verify_mfa"),
-        ("async_step_reauth_verify_mfa", "reauth_verify_mfa"),
+        ("async_step_verify_mfa", "verify_mfa", None),
+        ("async_step_reauth_verify_mfa", "reauth_verify_mfa", None),
+        ("async_step_reconfigure_verify_mfa", "reconfigure_verify_mfa", SOURCE_RECONFIGURE),
     ],
 )
 async def test_async_step_verify_mfa_status_variants(
     flow: MyAirConfigFlow,
     step_name: str,
     expected_step_id: str,
+    source: str | None,
     myair_client: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Non-success MFA statuses keep the flow on the correct error form."""
     flow._client = myair_client
     flow._data = {CONF_USER_NAME: "user"}
+    if source == SOURCE_RECONFIGURE:
+        flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
+        flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
     user_input = {CONF_VERIFICATION_CODE: "badcode"}
     monkeypatch.setattr(
         config_flow,
@@ -1051,10 +1081,16 @@ async def test_async_step_user_not_device_or_not_authn_success(
 
 
 @pytest.mark.parametrize(
-    ("step_name", "expected_step_id", "needs_entry"),
+    ("step_name", "expected_step_id", "source", "needs_entry"),
     [
-        ("async_step_verify_mfa", "verify_mfa", False),
-        ("async_step_reauth_verify_mfa", "reauth_verify_mfa", True),
+        ("async_step_verify_mfa", "verify_mfa", None, False),
+        ("async_step_reauth_verify_mfa", "reauth_verify_mfa", None, True),
+        (
+            "async_step_reconfigure_verify_mfa",
+            "reconfigure_verify_mfa",
+            SOURCE_RECONFIGURE,
+            True,
+        ),
     ],
 )
 @pytest.mark.asyncio
@@ -1065,6 +1101,7 @@ async def test_async_step_verify_mfa_parsing_error_variants(
     myair_client: MagicMock,
     step_name: str,
     expected_step_id: str,
+    source: str | None,
     needs_entry: bool,
 ) -> None:
     """Parsing errors keep MFA verification on the active form."""
@@ -1072,6 +1109,9 @@ async def test_async_step_verify_mfa_parsing_error_variants(
     flow._client = myair_client
     if needs_entry:
         flow._entry = config_entry
+    if source == SOURCE_RECONFIGURE:
+        flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
+        flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
 
     monkeypatch.setattr(
         config_flow,
@@ -1102,7 +1142,7 @@ async def test_async_step_reauth_no_entry(hass: MagicMock) -> None:
 
 
 @pytest.mark.parametrize(
-    ("step_name", "user_input", "flow_data", "expected_step_id", "needs_entry"),
+    ("step_name", "user_input", "flow_data", "expected_step_id", "expected_error", "needs_entry"),
     [
         (
             "async_step_user",
@@ -1113,6 +1153,7 @@ async def test_async_step_reauth_no_entry(hass: MagicMock) -> None:
             },
             {},
             "user",
+            "authentication_error",
             False,
         ),
         (
@@ -1128,6 +1169,40 @@ async def test_async_step_reauth_no_entry(hass: MagicMock) -> None:
                 CONF_DEVICE_TOKEN: "token",
             },
             "reauth_confirm",
+            "authentication_error",
+            True,
+        ),
+        (
+            "async_step_verify_mfa",
+            {CONF_VERIFICATION_CODE: "654321"},
+            {},
+            "verify_mfa",
+            "mfa_error",
+            False,
+        ),
+        (
+            "async_step_reconfigure",
+            {
+                CONF_USER_NAME: "user",
+                CONF_PASSWORD: "pw",
+                CONF_REGION: REGION_EU,
+            },
+            {},
+            "reconfigure",
+            "authentication_error",
+            True,
+        ),
+        (
+            "async_step_reconfigure_verify_mfa",
+            {CONF_VERIFICATION_CODE: "654321"},
+            {
+                CONF_USER_NAME: "user",
+                CONF_PASSWORD: "pw",
+                CONF_REGION: REGION_EU,
+                CONF_DEVICE_TOKEN: "token",
+            },
+            "reconfigure_verify_mfa",
+            "mfa_error",
             True,
         ),
     ],
@@ -1141,24 +1216,36 @@ async def test_async_step_device_missing_serial_number_variants(
     user_input: dict[str, str],
     flow_data: dict[str, str],
     expected_step_id: str,
+    expected_error: str,
     needs_entry: bool,
 ) -> None:
     """Missing device serial numbers keep the active auth form open."""
     flow._data = flow_data
     if needs_entry:
         flow._entry = config_entry
+    if step_name.startswith("async_step_reconfigure"):
+        flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
+        flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
     device = MyAirDevice.from_api({"fgDeviceManufacturerName": "ResMed", "localizedName": "CPAP"})
-    monkeypatch.setattr(
-        config_flow,
-        "get_device",
-        AsyncMock(return_value=(AUTHN_SUCCESS, device, MagicMock(spec=RESTClient))),
-    )
+    if "verify_mfa" in step_name:
+        flow._client = MagicMock(spec=RESTClient)
+        monkeypatch.setattr(
+            config_flow,
+            "get_mfa_device",
+            AsyncMock(return_value=(AUTHN_SUCCESS, device)),
+        )
+    else:
+        monkeypatch.setattr(
+            config_flow,
+            "get_device",
+            AsyncMock(return_value=(AUTHN_SUCCESS, device, MagicMock(spec=RESTClient))),
+        )
 
     result = await getattr(flow, step_name)(user_input)
 
     assert result["type"] == "form"
     assert result["step_id"] == expected_step_id
-    assert result["errors"]["base"] == "authentication_error"
+    assert result["errors"]["base"] == expected_error
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -31,7 +31,7 @@ from custom_components.resmed_myair.config_flow import (
 from custom_components.resmed_myair.models import MyAirDevice
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-TRANSLATION_LANGUAGES = ("en", "fr")
+TRANSLATION_LANGUAGES = ("de", "en", "es", "fr")
 CONFIG_FLOW_ABORT_REASONS = (
     "already_configured",
     "incomplete_account",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -51,6 +51,89 @@ def flow(hass: MagicMock) -> MyAirConfigFlow:
     return flow
 
 
+def _credential_data(
+    username: str,
+    password: str,
+    region: str,
+    device_token: str | None = None,
+) -> dict[str, str]:
+    """Return config-entry credential data for tests.
+
+    Args:
+        username: myAir account username.
+        password: myAir account password.
+        region: myAir region code.
+        device_token: Optional remembered-device token.
+
+    Returns:
+        Credential data shaped like a config-entry payload.
+    """
+    data = {
+        CONF_USER_NAME: username,
+        CONF_PASSWORD: password,
+        CONF_REGION: region,
+    }
+    if device_token is not None:
+        data[CONF_DEVICE_TOKEN] = device_token
+    return data
+
+
+def _reconfigure_entry(
+    unique_id: str | None = "SN123",
+    *,
+    entry_id: str = "mock_entry_id",
+    title: str = "ResMed-CPAP",
+    username: str = "old@example.com",
+) -> MockConfigEntry:
+    """Return a config entry shaped for reconfigure flow tests.
+
+    Args:
+        unique_id: Existing config-entry unique ID, or `None` for legacy entries.
+        entry_id: Config-entry ID to expose through flow context.
+        title: Config-entry title.
+        username: Stored account username.
+
+    Returns:
+        Mock config entry with myAir credential data.
+    """
+    return MockConfigEntry(
+        domain="resmed_myair",
+        title=title,
+        data=_credential_data(username, "old-password", REGION_NA, "old-token"),
+        entry_id=entry_id,
+        unique_id=unique_id,
+        version=2,
+    )
+
+
+def _prepare_reconfigure_flow(
+    flow: MyAirConfigFlow,
+    config_entry: MockConfigEntry,
+    myair_client: MagicMock,
+    *,
+    existing_unique_id_entry: MockConfigEntry | None = None,
+    flow_data: dict[str, str] | None = None,
+) -> None:
+    """Wire a config flow to an entry for reconfigure tests.
+
+    Args:
+        flow: Config flow under test.
+        config_entry: Entry returned by Home Assistant's known-entry lookup.
+        myair_client: REST client double held by the flow.
+        existing_unique_id_entry: Optional entry returned for duplicate unique ID lookup.
+        flow_data: Optional transient flow data to preload.
+    """
+    flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
+    flow._client = myair_client
+    flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
+    flow.hass.config_entries.async_entry_for_domain_unique_id = MagicMock(
+        return_value=existing_unique_id_entry
+    )
+    flow.hass.config_entries.async_schedule_reload = MagicMock()
+    if flow_data is not None:
+        flow._data = flow_data
+
+
 @pytest.mark.parametrize("language", TRANSLATION_LANGUAGES)
 def test_config_flow_abort_reasons_have_translations(language: str) -> None:
     """All config-flow abort reasons have localized strings."""
@@ -677,24 +760,12 @@ async def test_async_step_reauth_calls_confirm(
 
 @pytest.mark.asyncio
 async def test_async_step_reconfigure_success_updates_entry_and_schedules_reload(
-    hass: MagicMock,
+    flow: MyAirConfigFlow,
     myair_client: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Reconfigure validates the same device before updating setup data."""
-    config_entry = MockConfigEntry(
-        domain="resmed_myair",
-        title="ResMed-CPAP",
-        data={
-            CONF_USER_NAME: "old@example.com",
-            CONF_PASSWORD: "old-password",
-            CONF_REGION: REGION_NA,
-            CONF_DEVICE_TOKEN: "old-token",
-        },
-        entry_id="mock_entry_id",
-        unique_id="SN123",
-        version=2,
-    )
+    config_entry = _reconfigure_entry()
     device = MyAirDevice.from_api(
         {
             "serialNumber": "SN123",
@@ -708,11 +779,7 @@ async def test_async_step_reconfigure_success_updates_entry_and_schedules_reload
         "get_device",
         AsyncMock(return_value=(AUTHN_SUCCESS, device, myair_client)),
     )
-    hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
-    hass.config_entries.async_schedule_reload = MagicMock()
-    flow = MyAirConfigFlow()
-    flow.hass = hass
-    flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
+    _prepare_reconfigure_flow(flow, config_entry, myair_client)
 
     result = await flow.async_step_reconfigure(
         {
@@ -727,22 +794,19 @@ async def test_async_step_reconfigure_success_updates_entry_and_schedules_reload
     get_device_mock = config_flow.get_device
     assert isinstance(get_device_mock, AsyncMock)
     get_device_mock.assert_awaited_once_with(
-        hass,
+        flow.hass,
         "new@example.com",
         "new-password",
         REGION_EU,
         "old-token",
     )
-    hass.config_entries.async_get_known_entry.assert_any_call("mock_entry_id")
-    _, kwargs = hass.config_entries.async_update_entry.call_args
+    flow.hass.config_entries.async_get_known_entry.assert_any_call("mock_entry_id")
+    _, kwargs = flow.hass.config_entries.async_update_entry.call_args
     assert kwargs["entry"] is config_entry
-    assert kwargs["data"] == {
-        CONF_USER_NAME: "new@example.com",
-        CONF_PASSWORD: "new-password",
-        CONF_REGION: REGION_EU,
-        CONF_DEVICE_TOKEN: "new-token",
-    }
-    hass.config_entries.async_schedule_reload.assert_called_once_with("mock_entry_id")
+    assert kwargs["data"] == _credential_data(
+        "new@example.com", "new-password", REGION_EU, "new-token"
+    )
+    flow.hass.config_entries.async_schedule_reload.assert_called_once_with("mock_entry_id")
 
 
 @pytest.mark.asyncio
@@ -774,32 +838,14 @@ async def test_async_step_reconfigure_backfills_legacy_entry_unique_id(
     user_input: dict[str, str],
 ) -> None:
     """Reconfigure repairs legacy entries that have no unique ID."""
-    config_entry = MockConfigEntry(
-        domain="resmed_myair",
-        title="ResMed-CPAP",
-        data={
-            CONF_USER_NAME: "old@example.com",
-            CONF_PASSWORD: "old-password",
-            CONF_REGION: REGION_NA,
-            CONF_DEVICE_TOKEN: "old-token",
-        },
-        entry_id="mock_entry_id",
-        unique_id=None,
-        version=2,
+    flow_data = (
+        _credential_data("new@example.com", "new-password", REGION_EU, "old-token")
+        if step_name == "async_step_reconfigure_verify_mfa"
+        else None
     )
-    flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
-    flow._client = myair_client
-    flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
-    flow.hass.config_entries.async_entry_for_domain_unique_id = MagicMock(return_value=None)
-    flow.hass.config_entries.async_schedule_reload = MagicMock()
+    config_entry = _reconfigure_entry(unique_id=None)
+    _prepare_reconfigure_flow(flow, config_entry, myair_client, flow_data=flow_data)
     myair_client.device_token = "updated-token"
-    if step_name == "async_step_reconfigure_verify_mfa":
-        flow._data = {
-            CONF_USER_NAME: "new@example.com",
-            CONF_PASSWORD: "new-password",
-            CONF_REGION: REGION_EU,
-            CONF_DEVICE_TOKEN: "old-token",
-        }
     device = MyAirDevice.from_api(
         {
             "serialNumber": "SN123",
@@ -820,12 +866,9 @@ async def test_async_step_reconfigure_backfills_legacy_entry_unique_id(
     assert result["reason"] == "reconfigure_successful"
     _, kwargs = flow.hass.config_entries.async_update_entry.call_args
     assert kwargs["entry"] is config_entry
-    assert kwargs["data"] == {
-        CONF_USER_NAME: "new@example.com",
-        CONF_PASSWORD: "new-password",
-        CONF_REGION: REGION_EU,
-        CONF_DEVICE_TOKEN: "updated-token",
-    }
+    assert kwargs["data"] == _credential_data(
+        "new@example.com", "new-password", REGION_EU, "updated-token"
+    )
     assert kwargs["unique_id"] == "SN123"
     flow.hass.config_entries.async_schedule_reload.assert_called_once_with("mock_entry_id")
 
@@ -859,29 +902,13 @@ async def test_async_step_reconfigure_aborts_on_unverified_device_identity(
     user_input: dict[str, str],
 ) -> None:
     """Reconfigure refuses to update an entry when device identity changes."""
-    config_entry = MockConfigEntry(
-        domain="resmed_myair",
-        title="ResMed-CPAP",
-        data={
-            CONF_USER_NAME: "old@example.com",
-            CONF_PASSWORD: "old-password",
-            CONF_REGION: REGION_NA,
-            CONF_DEVICE_TOKEN: "old-token",
-        },
-        entry_id="mock_entry_id",
-        unique_id="SN123",
-        version=2,
+    flow_data = (
+        _credential_data("new@example.com", "new-password", REGION_EU, "old-token")
+        if step_name == "async_step_reconfigure_verify_mfa"
+        else None
     )
-    flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
-    flow._client = myair_client
-    flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
-    if step_name == "async_step_reconfigure_verify_mfa":
-        flow._data = {
-            CONF_USER_NAME: "new@example.com",
-            CONF_PASSWORD: "new-password",
-            CONF_REGION: REGION_EU,
-            CONF_DEVICE_TOKEN: "old-token",
-        }
+    config_entry = _reconfigure_entry()
+    _prepare_reconfigure_flow(flow, config_entry, myair_client, flow_data=flow_data)
     mismatched_device = MyAirDevice.from_api(
         {
             "serialNumber": "SN999",
@@ -910,32 +937,21 @@ async def test_async_step_reconfigure_legacy_backfill_aborts_on_duplicate_unique
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Legacy reconfigure refuses to backfill a serial used by another entry."""
-    legacy_entry = MockConfigEntry(
-        domain="resmed_myair",
-        title="Legacy ResMed-CPAP",
-        data={
-            CONF_USER_NAME: "old@example.com",
-            CONF_PASSWORD: "old-password",
-            CONF_REGION: REGION_NA,
-            CONF_DEVICE_TOKEN: "old-token",
-        },
-        entry_id="legacy_entry",
+    legacy_entry = _reconfigure_entry(
         unique_id=None,
-        version=2,
+        entry_id="legacy_entry",
+        title="Legacy ResMed-CPAP",
     )
-    existing_entry = MockConfigEntry(
-        domain="resmed_myair",
-        title="Existing ResMed-CPAP",
-        data={CONF_USER_NAME: "existing@example.com"},
+    existing_entry = _reconfigure_entry(
         entry_id="existing_entry",
-        unique_id="SN123",
-        version=2,
+        title="Existing ResMed-CPAP",
+        username="existing@example.com",
     )
-    flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": legacy_entry.entry_id}
-    flow._client = myair_client
-    flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=legacy_entry)
-    flow.hass.config_entries.async_entry_for_domain_unique_id = MagicMock(
-        return_value=existing_entry
+    _prepare_reconfigure_flow(
+        flow,
+        legacy_entry,
+        myair_client,
+        existing_unique_id_entry=existing_entry,
     )
     myair_client.device_token = "updated-token"
     device = MyAirDevice.from_api(
@@ -1017,30 +1033,14 @@ async def test_async_step_reconfigure_incomplete_account_abort_variants(
     expected_abort_reason: str,
 ) -> None:
     """Reconfigure steps preserve incomplete-account abort handling."""
-    config_entry = MockConfigEntry(
-        domain="resmed_myair",
-        title="ResMed-CPAP",
-        data={
-            CONF_USER_NAME: "old@example.com",
-            CONF_PASSWORD: "old-password",
-            CONF_REGION: REGION_NA,
-            CONF_DEVICE_TOKEN: "old-token",
-        },
-        entry_id="mock_entry_id",
-        unique_id="SN123",
-        version=2,
+    flow_data = (
+        _credential_data("new@example.com", "new-password", REGION_EU, "old-token")
+        if step_name == "async_step_reconfigure_verify_mfa"
+        else None
     )
-    flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
-    flow._client = myair_client
-    flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
+    config_entry = _reconfigure_entry()
+    _prepare_reconfigure_flow(flow, config_entry, myair_client, flow_data=flow_data)
     flow._client.is_email_verified = AsyncMock(return_value=is_email_verified)
-    if step_name == "async_step_reconfigure_verify_mfa":
-        flow._data = {
-            CONF_USER_NAME: "new@example.com",
-            CONF_PASSWORD: "new-password",
-            CONF_REGION: REGION_EU,
-            CONF_DEVICE_TOKEN: "old-token",
-        }
     monkeypatch.setattr(
         config_flow,
         helper_name,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -716,6 +716,90 @@ async def test_async_step_reconfigure_success_updates_entry_and_schedules_reload
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("step_name", "helper_name", "user_input"),
+    [
+        (
+            "async_step_reconfigure",
+            "get_device",
+            {
+                CONF_USER_NAME: "new@example.com",
+                CONF_PASSWORD: "new-password",
+                CONF_REGION: REGION_EU,
+            },
+        ),
+        (
+            "async_step_reconfigure_verify_mfa",
+            "get_mfa_device",
+            {CONF_VERIFICATION_CODE: "654321"},
+        ),
+    ],
+)
+async def test_async_step_reconfigure_backfills_legacy_entry_unique_id(
+    flow: MyAirConfigFlow,
+    myair_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    step_name: str,
+    helper_name: str,
+    user_input: dict[str, str],
+) -> None:
+    """Reconfigure repairs legacy entries that have no unique ID."""
+    config_entry = MockConfigEntry(
+        domain="resmed_myair",
+        title="ResMed-CPAP",
+        data={
+            CONF_USER_NAME: "old@example.com",
+            CONF_PASSWORD: "old-password",
+            CONF_REGION: REGION_NA,
+            CONF_DEVICE_TOKEN: "old-token",
+        },
+        entry_id="mock_entry_id",
+        unique_id=None,
+        version=2,
+    )
+    flow.context = {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id}
+    flow._client = myair_client
+    flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
+    flow.hass.config_entries.async_schedule_reload = MagicMock()
+    myair_client.device_token = "updated-token"
+    if step_name == "async_step_reconfigure_verify_mfa":
+        flow._data = {
+            CONF_USER_NAME: "new@example.com",
+            CONF_PASSWORD: "new-password",
+            CONF_REGION: REGION_EU,
+            CONF_DEVICE_TOKEN: "old-token",
+        }
+    device = MyAirDevice.from_api(
+        {
+            "serialNumber": "SN123",
+            "fgDeviceManufacturerName": "ResMed",
+            "localizedName": "CPAP",
+        }
+    )
+    helper_result = (
+        (AUTHN_SUCCESS, device, myair_client)
+        if helper_name == "get_device"
+        else (AUTHN_SUCCESS, device)
+    )
+    monkeypatch.setattr(config_flow, helper_name, AsyncMock(return_value=helper_result))
+
+    result = await getattr(flow, step_name)(user_input)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reconfigure_successful"
+    _, kwargs = flow.hass.config_entries.async_update_entry.call_args
+    assert kwargs["entry"] is config_entry
+    assert kwargs["data"] == {
+        CONF_USER_NAME: "new@example.com",
+        CONF_PASSWORD: "new-password",
+        CONF_REGION: REGION_EU,
+        CONF_DEVICE_TOKEN: "updated-token",
+    }
+    assert kwargs["unique_id"] == "SN123"
+    flow.hass.config_entries.async_schedule_reload.assert_called_once_with("mock_entry_id")
+
+
+@pytest.mark.asyncio
 async def test_async_step_user_not_device_or_not_authn_success(
     monkeypatch: pytest.MonkeyPatch, hass: MagicMock
 ) -> None:

--- a/tests/test_config_flow_workflows.py
+++ b/tests/test_config_flow_workflows.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock
 
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_RECONFIGURE
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -127,10 +128,10 @@ async def test_reauth_mfa_workflow_updates_entry_and_reloads(
     get_mfa_device = AsyncMock(return_value=(AUTHN_SUCCESS, _device()))
     monkeypatch.setattr(config_flow, "get_device", get_device)
     monkeypatch.setattr(config_flow, "get_mfa_device", get_mfa_device)
-    hass.config_entries.async_get_entry = MagicMock(return_value=config_entry)
+    hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
     hass.config_entries.async_update_entry = MagicMock()
-    hass.config_entries.async_reload = AsyncMock()
-    flow = _flow(hass, {"entry_id": config_entry.entry_id})
+    hass.config_entries.async_schedule_reload = MagicMock()
+    flow = _flow(hass, {"source": SOURCE_REAUTH, "entry_id": config_entry.entry_id})
 
     confirm_form = await flow.async_step_reauth(dict(entry_data))
     mfa_form = await flow.async_step_reauth_confirm(
@@ -155,13 +156,75 @@ async def test_reauth_mfa_workflow_updates_entry_and_reloads(
         "old-token",
     )
     get_mfa_device.assert_awaited_once_with(myair_client, "654321")
-    hass.config_entries.async_update_entry.assert_called_once_with(
-        config_entry,
-        data={
+    _, kwargs = hass.config_entries.async_update_entry.call_args
+    assert kwargs["entry"] is config_entry
+    assert kwargs["data"] == {
+        CONF_USER_NAME: "new@example.com",
+        CONF_PASSWORD: "new-password",
+        CONF_REGION: REGION_NA,
+        CONF_DEVICE_TOKEN: "new-token",
+    }
+    hass.config_entries.async_schedule_reload.assert_called_once_with("existing-entry")
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_mfa_workflow_updates_entry_and_reloads(
+    hass: MagicMock,
+    myair_client: RESTClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconfigure carries updated setup data through MFA, update, and reload."""
+    entry_data = {
+        CONF_USER_NAME: "old@example.com",
+        CONF_PASSWORD: "old-password",
+        CONF_REGION: REGION_NA,
+        CONF_DEVICE_TOKEN: "old-token",
+    }
+    config_entry = MockConfigEntry(
+        domain="resmed_myair",
+        title="ResMed-Bedroom CPAP",
+        data=entry_data,
+        entry_id="existing-entry",
+        unique_id="SN123",
+        version=2,
+    )
+    myair_client.device_token = "new-token"
+    get_device = AsyncMock(return_value=("MFA_REQUIRED", None, myair_client))
+    get_mfa_device = AsyncMock(return_value=(AUTHN_SUCCESS, _device()))
+    monkeypatch.setattr(config_flow, "get_device", get_device)
+    monkeypatch.setattr(config_flow, "get_mfa_device", get_mfa_device)
+    hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
+    hass.config_entries.async_update_entry = MagicMock()
+    hass.config_entries.async_schedule_reload = MagicMock()
+    flow = _flow(hass, {"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id})
+
+    mfa_form = await flow.async_step_reconfigure(
+        {
             CONF_USER_NAME: "new@example.com",
             CONF_PASSWORD: "new-password",
-            CONF_REGION: REGION_NA,
-            CONF_DEVICE_TOKEN: "new-token",
-        },
+            CONF_REGION: REGION_EU,
+        }
     )
-    hass.config_entries.async_reload.assert_awaited_once_with("existing-entry")
+    result = await flow.async_step_reconfigure_verify_mfa({CONF_VERIFICATION_CODE: "654321"})
+
+    assert mfa_form["type"] == "form"
+    assert mfa_form["step_id"] == "reconfigure_verify_mfa"
+    assert result["type"] == "abort"
+    assert result["reason"] == "reconfigure_successful"
+    get_device.assert_awaited_once_with(
+        hass,
+        "new@example.com",
+        "new-password",
+        REGION_EU,
+        "old-token",
+    )
+    get_mfa_device.assert_awaited_once_with(myair_client, "654321")
+    _, kwargs = hass.config_entries.async_update_entry.call_args
+    assert kwargs["entry"] is config_entry
+    assert kwargs["data"] == {
+        CONF_USER_NAME: "new@example.com",
+        CONF_PASSWORD: "new-password",
+        CONF_REGION: REGION_EU,
+        CONF_DEVICE_TOKEN: "new-token",
+    }
+    hass.config_entries.async_schedule_reload.assert_called_once_with("existing-entry")


### PR DESCRIPTION
## Summary
Adds Home Assistant config-entry reconfigure support for ResMed myAir so existing entries can update credentials and region without removing the integration. The flow validates that replacement credentials still belong to the configured device before updating the entry.

## What Changed
- Added reconfigure and reconfigure MFA steps that reuse remembered device tokens, preserve MFA handling, and schedule an entry reload after successful updates.
- Consolidated shared credential, MFA, and entry-update flow helpers used by setup, reauth, and reconfigure paths.
- Backfilled missing unique IDs for legacy entries during reauth or reconfigure when the authenticated device serial can be verified.
- Guarded reconfigure updates against wrong-account credentials and duplicate legacy unique ID backfills.
- Added German and Spanish config-flow translations, plus reconfigure strings for existing English and French translations.
- Updated codespell exclusions for localized translation files.
- Expanded config-flow and workflow tests for reconfigure success, MFA, incomplete-account aborts, device identity checks, legacy unique ID repair, duplicate protection, and translation coverage.

## Why
Home Assistant supports a dedicated reconfigure workflow for integrations that need editable setup options. Using that workflow here avoids requiring users to delete and recreate the integration when myAir credentials or region need to change, while preserving the integration's device identity safeguards.

