### PR TITLE
Add myAir live smoke-test utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__
 .coverage.*
 .DS_Store
 .env
+live_smoke_test.env
+live_smoke_test_output.json
 .mypy_cache
 .pytest_cache
 .qodo

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # resmed_myair
-[![Integration Usage](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https%3A%2F%2Fanalytics.home-assistant.io%2Fcustom_integrations.json&query=%24.resmed_myair.total)](https://analytics.home-assistant.io/custom_integrations.json)
+[![Integration Usage][integration-usage-shield]][integration-usage]
 
 [![GitHub Downloads][downloads-shield]][releases]
 [![GitHub Latest Downloads][downloads-latest-shield]][releases]
@@ -55,33 +55,27 @@ This integration was reversed engineered from the myAir website. There are no gu
 
 This integration currently only connects to accounts from North America, Europe, and Australia. If you are in Asia and have access to the ResMed myAir website in your country (<https://myair.resmed.com>), please open an issue and offer yourself as a test subject.
 
-## Contributions are welcome!
-
-If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)
-
 ## Manual live smoke test
 
 Developers can run a local smoke test against the live myAir API without Home Assistant:
 
 ```bash
-./.venv/bin/python scripts/live_smoke_test.py
+./scripts/live_smoke_test
 ```
 
-The script prompts for credentials when they are not provided. For repeatable local runs, create a `live_smoke_test.env` file:
-
-```env
-MYAIR_USERNAME="user@example.com"
-MYAIR_PASSWORD="password"
-MYAIR_REGION="NA"
-# Optional values:
-# MYAIR_DEVICE_TOKEN="remembered-device-token"
-# MYAIR_MFA_CODE="123456"
-```
+The script prompts for credentials when they are not provided. For repeatable local runs, create a `live_smoke_test.env` file using `live_smoke_test.env.example`.
 
 By default, output is written to `live_smoke_test_output.json` with the same fields shown in the sensor list above. Add `--raw` to include raw myAir payload values for local inspection. Known GraphQL types and fields are documented in `scripts/graphql_schema.json`.
 
+## Contributions are welcome!
+
+If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)
+
 If you want to support the development of this component, please don't donate to me but instead donate to the Home Assistant development team.
 
+
+[integration-usage-shield]: https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https%3A%2F%2Fanalytics.home-assistant.io%2Fcustom_integrations.json&query=%24.resmed_myair.total&style=for-the-badge
+[integration-usage]: https://analytics.home-assistant.io/custom_integrations.json
 [commits-shield]: https://img.shields.io/github/last-commit/prestomation/resmed_myair_sensors?style=for-the-badge
 [commits]: https://github.com/prestomation/resmed_myair_sensors/commits/main
 [hacs]: https://github.com/custom-components/hacs

--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@ This integration currently only connects to accounts from North America, Europe,
 
 If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)
 
+## Manual live smoke test
+
+Developers can run a local smoke test against the live myAir API without Home Assistant:
+
+```bash
+./.venv/bin/python scripts/live_smoke_test.py
+```
+
+The script prompts for credentials when they are not provided. For repeatable local runs, create a `live_smoke_test.env` file:
+
+```env
+MYAIR_USERNAME="user@example.com"
+MYAIR_PASSWORD="password"
+MYAIR_REGION="NA"
+# Optional values:
+# MYAIR_DEVICE_TOKEN="remembered-device-token"
+# MYAIR_MFA_CODE="123456"
+```
+
+By default, output is written to `live_smoke_test_output.json` with the same fields shown in the sensor list above. Add `--raw` to include raw myAir payload values for local inspection. Known GraphQL types and fields are documented in `scripts/graphql_schema.json`.
+
 If you want to support the development of this component, please don't donate to me but instead donate to the Home Assistant development team.
 
 [commits-shield]: https://img.shields.io/github/last-commit/prestomation/resmed_myair_sensors?style=for-the-badge

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository-local utility scripts."""

--- a/scripts/graphql_schema.json
+++ b/scripts/graphql_schema.json
@@ -1,0 +1,114 @@
+{
+  "source": "Manual schema notes from working integration queries and validation probes.",
+  "introspection": {
+    "available": false,
+    "notes": [
+      "The ResMed AppSync endpoint accepts __typename.",
+      "__schema { __typename } works.",
+      "Standard introspection fields such as __schema.queryType, __schema.types, __type.name, __type.kind, and __type.fields return FieldUndefined validation errors."
+    ]
+  },
+  "queries": {
+    "getPatientWrapper": {
+      "type": "PatientWrapper",
+      "confirmed_fields": {
+        "__typename": {
+          "type": "String",
+          "source": "validation probe"
+        },
+        "patient": {
+          "type": "Patient",
+          "source": "working integration query"
+        },
+        "masks": {
+          "type": "[Mask]",
+          "source": "working integration query"
+        },
+        "fgDevices": {
+          "type": "[FgDevice]",
+          "source": "working integration query"
+        },
+        "sleepRecords": {
+          "type": "SleepRecordConnection",
+          "arguments": {
+            "startMonth": "String",
+            "endMonth": "String"
+          },
+          "source": "working integration query"
+        }
+      }
+    }
+  },
+  "types": {
+    "PatientWrapper": {
+      "confirmed_fields": {
+        "patient": "Patient",
+        "masks": "[Mask]",
+        "fgDevices": "[FgDevice]",
+        "sleepRecords(startMonth: String, endMonth: String)": "SleepRecordConnection"
+      },
+      "type_name_source": "validation probe"
+    },
+    "Patient": {
+      "confirmed_fields": {
+        "firstName": "String"
+      },
+      "type_name_source": "validation probe"
+    },
+    "Mask": {
+      "confirmed_fields": {
+        "maskCode": "String"
+      },
+      "type_name_source": "validation probe"
+    },
+    "FgDevice": {
+      "confirmed_fields": {
+        "serialNumber": "String",
+        "localizedName": "String",
+        "deviceSeries": "String",
+        "deviceFamily": "String",
+        "deviceType": "String",
+        "lastSleepDataReportTime": "String",
+        "fgDeviceManufacturerName": "String",
+        "fgDevicePatientId": "String",
+        "maskCode": "String"
+      },
+      "notes": [
+        "maskCode is copied onto device output by the integration from the first Mask item; it is not confirmed as a native FgDevice GraphQL field."
+      ],
+      "type_name_source": "validation probe"
+    },
+    "SleepRecordConnection": {
+      "confirmed_fields": {
+        "items": "[SleepRecord]",
+        "__typename": "String"
+      },
+      "type_name_source": "inferred from working query shape"
+    },
+    "SleepRecord": {
+      "confirmed_fields": {
+        "startDate": "String",
+        "totalUsage": "Int",
+        "sleepScore": "Int",
+        "usageScore": "Int",
+        "ahiScore": "Int",
+        "maskScore": "Int",
+        "leakScore": "Int",
+        "ahi": "Float",
+        "maskPairCount": "Int",
+        "leakPercentile": "Float",
+        "sleepRecordPatientId": "String",
+        "__typename": "String"
+      },
+      "type_name_source": "validation probe"
+    }
+  },
+  "known_operations": {
+    "getPatientWrapper": {
+      "query": "query getPatientWrapper { getPatientWrapper { masks { maskCode } fgDevices { serialNumber localizedName deviceSeries deviceFamily lastSleepDataReportTime fgDeviceManufacturerName fgDevicePatientId } } }"
+    },
+    "GetPatientSleepRecords": {
+      "query": "query GetPatientSleepRecords { getPatientWrapper { patient { firstName } sleepRecords(startMonth: \"YYYY-MM-DD\", endMonth: \"YYYY-MM-DD\") { items { startDate totalUsage sleepScore usageScore ahiScore maskScore leakScore ahi maskPairCount leakPercentile sleepRecordPatientId __typename } __typename } __typename } }"
+    }
+  }
+}

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ ! -x .venv/bin/prek ] || [ ! -x .venv/bin/mypy ]; then
+	scripts/setup
+fi
+
+status=0
+
+.venv/bin/prek run -a || status=$?
+
+exit "$status"

--- a/scripts/live_smoke_test
+++ b/scripts/live_smoke_test
@@ -7,8 +7,7 @@ export RESMED_MYAIR_LIVE_SMOKE_CWD="$PWD"
 cd "$(dirname "$0")/.."
 
 if [ ! -x .venv/bin/python ]; then
-	echo "Missing .venv Python. Create the repo venv before running this script." >&2
-	exit 1
+	scripts/setup
 fi
 
 if [ -f scripts/live_smoke_test.env ]; then

--- a/scripts/live_smoke_test
+++ b/scripts/live_smoke_test
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export RESMED_MYAIR_LIVE_SMOKE_CWD="$PWD"
+
+cd "$(dirname "$0")/.."
+
+if [ ! -x .venv/bin/python ]; then
+	echo "Missing .venv Python. Create the repo venv before running this script." >&2
+	exit 1
+fi
+
+if [ -f scripts/live_smoke_test.env ]; then
+	exec .venv/bin/python scripts/live_smoke_test.py --env-file scripts/live_smoke_test.env "$@"
+fi
+
+exec .venv/bin/python scripts/live_smoke_test.py "$@"

--- a/scripts/live_smoke_test.env.example
+++ b/scripts/live_smoke_test.env.example
@@ -1,0 +1,7 @@
+MYAIR_USERNAME="user@example.com"
+MYAIR_PASSWORD="password"
+MYAIR_REGION="NA"
+
+# Optional values:
+# MYAIR_DEVICE_TOKEN="remembered-device-token"
+# MYAIR_MFA_CODE="123456"

--- a/scripts/live_smoke_test.py
+++ b/scripts/live_smoke_test.py
@@ -1,0 +1,387 @@
+"""Manual live smoke test for ResMed myAir credentials and payload discovery."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections.abc import Mapping
+from datetime import date, datetime
+import getpass
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+from aiohttp import ClientConnectionError, ClientResponseError, ClientSession
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from custom_components.resmed_myair.client.const import (  # noqa: E402
+    AUTH_NEEDS_MFA,
+    AUTHN_SUCCESS,
+    REGION_NA,
+)
+from custom_components.resmed_myair.client.myair_client import (  # noqa: E402
+    AuthenticationError,
+    IncompleteAccountError,
+    MyAirConfig,
+    ParsingError,
+)
+from custom_components.resmed_myair.client.rest_client import RESTClient  # noqa: E402
+from custom_components.resmed_myair.models import MyAirCoordinatorData  # noqa: E402
+
+DEFAULT_ENV_FILE = Path("live_smoke_test.env")
+DEFAULT_OUTPUT_FILE = Path("live_smoke_test_output.json")
+ENV_USERNAME = "MYAIR_USERNAME"
+ENV_PASSWORD = "MYAIR_PASSWORD"  # noqa: S105
+ENV_REGION = "MYAIR_REGION"
+ENV_DEVICE_TOKEN = "MYAIR_DEVICE_TOKEN"  # noqa: S105
+ENV_MFA_CODE = "MYAIR_MFA_CODE"
+
+
+def load_env_file(path: Path) -> dict[str, str]:
+    """Load simple KEY=VALUE assignments from an env file.
+
+    Args:
+        path: Env file to parse.
+
+    Returns:
+        Parsed environment assignments. Missing files return an empty mapping.
+    """
+    if not path.exists():
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line.removeprefix("export ").strip()
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if (value.startswith('"') and value.endswith('"')) or (
+            value.startswith("'") and value.endswith("'")
+        ):
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def _get_setting(
+    env_values: Mapping[str, str],
+    key: str,
+    prompt: str,
+    *,
+    secret: bool = False,
+    default: str | None = None,
+    no_prompt: bool = False,
+) -> str:
+    """Resolve one setting from env file, process env, default, or prompt.
+
+    Args:
+        env_values: Values loaded from the optional env file.
+        key: Environment variable name to resolve.
+        prompt: Prompt shown when interactive input is needed.
+        secret: Whether to use `getpass` for prompt input.
+        default: Optional fallback value.
+        no_prompt: Whether missing values should fail instead of prompting.
+
+    Returns:
+        Resolved setting value.
+
+    Raises:
+        ValueError: If no value is available and prompts are disabled.
+    """
+    value = env_values.get(key) or os.environ.get(key) or default
+    if value:
+        return value
+    if no_prompt:
+        raise ValueError(f"{key} is required when --no-prompt is used")
+    if secret:
+        return getpass.getpass(f"{prompt}: ")
+    return input(f"{prompt}: ")
+
+
+def build_config(env_values: Mapping[str, str], no_prompt: bool = False) -> MyAirConfig:
+    """Build a myAir client config from env values or interactive prompts.
+
+    Args:
+        env_values: Values loaded from the optional env file.
+        no_prompt: Whether missing credentials should raise instead of prompting.
+
+    Returns:
+        Config consumed by the existing REST client.
+    """
+    return MyAirConfig(
+        username=_get_setting(env_values, ENV_USERNAME, "myAir username", no_prompt=no_prompt),
+        password=_get_setting(
+            env_values,
+            ENV_PASSWORD,
+            "myAir password",
+            secret=True,
+            no_prompt=no_prompt,
+        ),
+        region=_get_setting(
+            env_values,
+            ENV_REGION,
+            "myAir region",
+            default=REGION_NA,
+            no_prompt=no_prompt,
+        ),
+        device_token=env_values.get(ENV_DEVICE_TOKEN) or os.environ.get(ENV_DEVICE_TOKEN),
+    )
+
+
+def _serialize_value(value: Any) -> Any:
+    """Convert date-like values before JSON serialization.
+
+    Args:
+        value: Value passed by `json.dumps`.
+
+    Returns:
+        JSON-compatible representation.
+
+    Raises:
+        TypeError: If the value is unsupported by this serializer.
+    """
+    if isinstance(value, date | datetime):
+        return value.isoformat()
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def write_json_payload(path: Path, payload: Mapping[str, Any]) -> None:
+    """Write a stable JSON payload to disk.
+
+    Args:
+        path: Output path to create.
+        payload: JSON-compatible payload to serialize.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"{json.dumps(payload, indent=2, sort_keys=True, default=_serialize_value)}\n",
+        encoding="utf-8",
+    )
+
+
+def build_default_payload(
+    data: MyAirCoordinatorData,
+    *,
+    status: str,
+    region: str,
+) -> dict[str, Any]:
+    """Build the default smoke-test output from README sensor fields.
+
+    Args:
+        data: Device and sleep records returned by myAir.
+        status: Final authentication status.
+        region: myAir region used for the request.
+
+    Returns:
+        JSON-compatible payload containing the README sensor values.
+    """
+    device = data.device
+    latest_record = data.latest_sleep_record
+    return {
+        "status": status,
+        "region": region,
+        "device": {
+            "manufacturer": device.manufacturer if device else None,
+            "model": device.native_value("deviceType") if device else None,
+            "name": device.name if device else None,
+            "serial_number": device.serial_number if device else None,
+        },
+        "sensors": {
+            "cpap_ahi_events_per_hour": latest_record.native_value("ahi")
+            if latest_record
+            else None,
+            "cpap_usage_minutes": latest_record.total_usage_minutes if latest_record else None,
+            "cpap_mask_on_off_count": latest_record.native_value("maskPairCount")
+            if latest_record
+            else None,
+            "cpap_current_data_date": latest_record.start_date.isoformat()
+            if latest_record and latest_record.start_date
+            else None,
+            "cpap_mask_leak_percent": latest_record.native_value("leakPercentile")
+            if latest_record
+            else None,
+            "cpap_total_myair_score": latest_record.native_value("sleepScore")
+            if latest_record
+            else None,
+            "cpap_sleep_data_last_collected": device.native_value("lastSleepDataReportTime")
+            if device
+            else None,
+            "most_recent_sleep_date": data.most_recent_sleep_date.isoformat()
+            if data.most_recent_sleep_date
+            else None,
+        },
+        "record_count": len(data.sleep_records),
+    }
+
+
+def build_raw_payload(data: MyAirCoordinatorData) -> dict[str, Any]:
+    """Build a raw payload for local inspection.
+
+    Args:
+        data: Device and sleep records returned by myAir.
+
+    Returns:
+        Raw device and sleep-record payloads from myAir.
+    """
+    return {
+        "device": data.device.raw if data.device else None,
+        "sleep_records": [record.raw for record in data.sleep_records],
+    }
+
+
+async def _authenticate(client: RESTClient, env_values: Mapping[str, str], no_prompt: bool) -> str:
+    """Authenticate, prompting for MFA when the account requires it.
+
+    Args:
+        client: Client to authenticate.
+        env_values: Values loaded from the optional env file.
+        no_prompt: Whether missing MFA codes should raise instead of prompting.
+
+    Returns:
+        Final authentication status.
+    """
+    status = await client.connect(initial=True)
+    if status != AUTH_NEEDS_MFA:
+        return status
+
+    verification_code = _get_setting(
+        env_values,
+        ENV_MFA_CODE,
+        "myAir MFA verification code",
+        no_prompt=no_prompt,
+    )
+    return await client.verify_mfa_and_get_access_token(verification_code)
+
+
+async def run_live_smoke_test(
+    config: MyAirConfig,
+    env_values: Mapping[str, str],
+    *,
+    include_raw: bool,
+    no_prompt: bool,
+) -> dict[str, Any]:
+    """Run the live myAir smoke test and return the selected output payload.
+
+    Args:
+        config: myAir credentials and region.
+        env_values: Values loaded from the optional env file.
+        include_raw: Whether to include raw payload values.
+        no_prompt: Whether missing MFA codes should raise instead of prompting.
+
+    Returns:
+        JSON-compatible smoke-test output.
+    """
+    async with ClientSession() as session:
+        client = RESTClient(config, session)
+        status = await _authenticate(client, env_values, no_prompt)
+        if status != AUTHN_SUCCESS:
+            raise AuthenticationError(f"Unexpected authentication status: {status}")
+        device = await client.get_user_device_data(initial=True)
+        sleep_records = await client.get_sleep_records(initial=True)
+
+    data = MyAirCoordinatorData(device=device, sleep_records=tuple(sleep_records))
+    payload = build_default_payload(data, status=status, region=config.region)
+    if client.device_token:
+        payload["device_token_available"] = True
+    if include_raw:
+        payload["raw"] = build_raw_payload(data)
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser for the smoke-test script.
+
+    Returns:
+        Configured argument parser.
+    """
+    parser = argparse.ArgumentParser(
+        description="Run a manual live smoke test against ResMed myAir.",
+    )
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        default=DEFAULT_ENV_FILE,
+        help=f"env file containing credentials; default: {DEFAULT_ENV_FILE}",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_FILE,
+        help=f"JSON output path; default: {DEFAULT_OUTPUT_FILE}",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="include raw myAir payload values in the output file",
+    )
+    parser.add_argument(
+        "--no-prompt",
+        action="store_true",
+        help="fail when credentials or MFA code are missing instead of prompting",
+    )
+    return parser
+
+
+async def async_main(argv: list[str] | None = None) -> int:
+    """Run the smoke-test CLI asynchronously.
+
+    Args:
+        argv: Optional argument list for tests.
+
+    Returns:
+        Process exit code.
+    """
+    args = build_parser().parse_args(argv)
+    env_values = load_env_file(args.env_file)
+    config = build_config(env_values, no_prompt=args.no_prompt)
+    payload = await run_live_smoke_test(
+        config,
+        env_values,
+        include_raw=args.raw,
+        no_prompt=args.no_prompt,
+    )
+    write_json_payload(args.output, payload)
+    print(f"Wrote live myAir smoke-test output to {args.output}")  # noqa: T201
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the smoke-test CLI.
+
+    Args:
+        argv: Optional argument list for tests.
+
+    Returns:
+        Process exit code.
+    """
+    try:
+        return asyncio.run(async_main(argv))
+    except (
+        AuthenticationError,
+        ClientConnectionError,
+        ClientResponseError,
+        IncompleteAccountError,
+        OSError,
+        ParsingError,
+        ValueError,
+    ) as err:
+        print(  # noqa: T201
+            f"Live smoke test failed: {type(err).__name__}: {err}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if ! command -v python3.14 >/dev/null 2>&1; then
+	echo "python3.14 is required to create this project's virtualenv." >&2
+	exit 1
+fi
+
+if [ -f .venv/pyvenv.cfg ] && ! grep -qE '^version = 3\.14(\.|$)' .venv/pyvenv.cfg; then
+	echo "Existing .venv uses the wrong Python version. Remove .venv and rerun scripts/setup." >&2
+	exit 1
+fi
+
+python3.14 -m venv .venv
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install --group dev -e .
+.venv/bin/prek install

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ ! -x .venv/bin/python ]; then
+	scripts/setup
+fi
+
+.venv/bin/python -m pytest "$@"

--- a/tests/test_live_smoke_test.py
+++ b/tests/test_live_smoke_test.py
@@ -1,0 +1,126 @@
+"""Tests for the manual myAir live smoke-test script."""
+
+from __future__ import annotations
+
+from datetime import date
+import importlib.util
+from pathlib import Path
+import subprocess
+
+from custom_components.resmed_myair.models import (
+    MyAirCoordinatorData,
+    MyAirDevice,
+    MyAirSleepRecord,
+)
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "live_smoke_test.py"
+WRAPPER_PATH = Path(__file__).resolve().parents[1] / "scripts" / "live_smoke_test"
+SPEC = importlib.util.spec_from_file_location("live_smoke_test", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+live_smoke_test = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(live_smoke_test)
+
+
+def test_shell_wrapper_runs_resmed_live_smoke_test_help() -> None:
+    """Shell wrapper invokes this repo's live smoke-test script."""
+    result = subprocess.run(  # noqa: S603
+        [str(WRAPPER_PATH), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Run a manual live smoke test against ResMed myAir." in result.stdout
+
+
+def test_load_env_file_parses_assignments_and_quoted_values(tmp_path: Path) -> None:
+    """Env-file loading accepts comments, blank lines, exports, and quotes."""
+    env_file = tmp_path / "live_smoke_test.env"
+    env_file.write_text(
+        """# local credentials
+export MYAIR_USERNAME='user@example.com'
+MYAIR_PASSWORD="secret value"
+MYAIR_REGION=EU
+IGNORED_LINE""",
+        encoding="utf-8",
+    )
+
+    values = live_smoke_test.load_env_file(env_file)
+
+    assert values == {
+        "MYAIR_USERNAME": "user@example.com",
+        "MYAIR_PASSWORD": "secret value",
+        "MYAIR_REGION": "EU",
+    }
+
+
+def test_build_default_payload_matches_readme_sensor_fields() -> None:
+    """Default output exposes the sensor fields listed in the README."""
+    data = MyAirCoordinatorData(
+        device=MyAirDevice.from_api(
+            {
+                "serialNumber": "SN123",
+                "localizedName": "Bedroom CPAP",
+                "fgDeviceManufacturerName": "ResMed",
+                "deviceType": "AirSense 11",
+                "lastSleepDataReportTime": "2026-05-30T11:22:33Z",
+            }
+        ),
+        sleep_records=(
+            MyAirSleepRecord.from_api(
+                {
+                    "startDate": "2026-05-29",
+                    "totalUsage": 0,
+                    "sleepScore": 0,
+                    "ahi": 0,
+                    "maskPairCount": 0,
+                    "leakPercentile": 0,
+                }
+            ),
+            MyAirSleepRecord.from_api(
+                {
+                    "startDate": "2026-05-30",
+                    "totalUsage": 421,
+                    "sleepScore": 92,
+                    "ahi": 1.2,
+                    "maskPairCount": 3,
+                    "leakPercentile": 8,
+                }
+            ),
+        ),
+    )
+
+    payload = live_smoke_test.build_default_payload(data, status="SUCCESS", region="NA")
+
+    assert payload == {
+        "status": "SUCCESS",
+        "region": "NA",
+        "device": {
+            "manufacturer": "ResMed",
+            "model": "AirSense 11",
+            "name": "Bedroom CPAP",
+            "serial_number": "SN123",
+        },
+        "sensors": {
+            "cpap_ahi_events_per_hour": 1.2,
+            "cpap_usage_minutes": 421,
+            "cpap_mask_on_off_count": 3,
+            "cpap_current_data_date": "2026-05-30",
+            "cpap_mask_leak_percent": 8,
+            "cpap_total_myair_score": 92,
+            "cpap_sleep_data_last_collected": "2026-05-30T11:22:33Z",
+            "most_recent_sleep_date": "2026-05-30",
+        },
+        "record_count": 2,
+    }
+
+
+def test_write_json_payload_serializes_dates(tmp_path: Path) -> None:
+    """Output writing serializes date values and creates parent directories."""
+    output_file = tmp_path / "nested" / "live_smoke_test_output.json"
+
+    live_smoke_test.write_json_payload(output_file, {"date": date(2026, 5, 30)})
+
+    assert output_file.read_text(encoding="utf-8") == '{\n  "date": "2026-05-30"\n}\n'

--- a/tests/test_live_smoke_test.py
+++ b/tests/test_live_smoke_test.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from datetime import date
 import importlib.util
 from pathlib import Path
-import subprocess
 
 from custom_components.resmed_myair.models import (
     MyAirCoordinatorData,
@@ -14,25 +13,11 @@ from custom_components.resmed_myair.models import (
 )
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "live_smoke_test.py"
-WRAPPER_PATH = Path(__file__).resolve().parents[1] / "scripts" / "live_smoke_test"
 SPEC = importlib.util.spec_from_file_location("live_smoke_test", SCRIPT_PATH)
 assert SPEC is not None
 assert SPEC.loader is not None
 live_smoke_test = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(live_smoke_test)
-
-
-def test_shell_wrapper_runs_resmed_live_smoke_test_help() -> None:
-    """Shell wrapper invokes this repo's live smoke-test script."""
-    result = subprocess.run(  # noqa: S603
-        [str(WRAPPER_PATH), "--help"],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 0
-    assert "Run a manual live smoke test against ResMed myAir." in result.stdout
 
 
 def test_load_env_file_parses_assignments_and_quoted_values(tmp_path: Path) -> None:

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,98 @@
+"""Tests for repository shell helper scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _copy_script_harness(tmp_path: Path, script_name: str) -> Path:
+    """Copy one shell script plus a fake setup script into a temporary repo.
+
+    Args:
+        tmp_path: Temporary directory supplied by pytest.
+        script_name: Name of the shell helper under `scripts`.
+
+    Returns:
+        Temporary repository root.
+    """
+    repo = tmp_path / "repo"
+    scripts = repo / "scripts"
+    scripts.mkdir(parents=True)
+    shutil.copy2(REPO_ROOT / "scripts" / script_name, scripts / script_name)
+    (scripts / "setup").write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p .venv/bin
+printf '#!/usr/bin/env bash\\necho python \"$@\" >> setup.log\\n' > .venv/bin/python
+printf '#!/usr/bin/env bash\\necho prek \"$@\" >> setup.log\\n' > .venv/bin/prek
+printf '#!/usr/bin/env bash\\necho mypy \"$@\" >> setup.log\\n' > .venv/bin/mypy
+chmod +x .venv/bin/python .venv/bin/prek .venv/bin/mypy
+echo setup >> setup.log
+""",
+        encoding="utf-8",
+    )
+    (scripts / "setup").chmod(0o755)
+    (scripts / script_name).chmod(0o755)
+    return repo
+
+
+def test_test_script_runs_setup_when_venv_is_missing(tmp_path: Path) -> None:
+    """Test helper bootstraps the venv before invoking pytest."""
+    repo = _copy_script_harness(tmp_path, "test")
+
+    result = subprocess.run(  # noqa: S603
+        [str(repo / "scripts" / "test"), "tests/test_example.py"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert (repo / "setup.log").read_text(encoding="utf-8").splitlines() == [
+        "setup",
+        "python -m pytest tests/test_example.py",
+    ]
+
+
+def test_lint_script_runs_setup_when_tools_are_missing(tmp_path: Path) -> None:
+    """Lint helper bootstraps missing lint tools before running prek."""
+    repo = _copy_script_harness(tmp_path, "lint")
+
+    result = subprocess.run(  # noqa: S603
+        [str(repo / "scripts" / "lint")],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert (repo / "setup.log").read_text(encoding="utf-8").splitlines() == [
+        "setup",
+        "prek run -a",
+    ]
+
+
+def test_live_smoke_test_script_runs_setup_when_venv_is_missing(tmp_path: Path) -> None:
+    """Live-smoke wrapper bootstraps the venv before invoking the Python script."""
+    repo = _copy_script_harness(tmp_path, "live_smoke_test")
+    (repo / "scripts" / "live_smoke_test.py").write_text(
+        "raise SystemExit(0)\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(  # noqa: S603
+        [str(repo / "scripts" / "live_smoke_test"), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert (repo / "setup.log").read_text(encoding="utf-8").splitlines() == [
+        "setup",
+        "python scripts/live_smoke_test.py --help",
+    ]


### PR DESCRIPTION
## Summary
Adds a manual myAir live smoke-test utility that can authenticate with credentials from prompts or an env file, fetch current device and sleep-record data, and write a JSON snapshot for local debugging.

## What Changed
- Added `scripts/live_smoke_test.py` for manual live API checks outside Home Assistant.
- Added `scripts/live_smoke_test` wrapper plus `scripts/live_smoke_test.env.example` for repeatable local runs.
- Added `scripts/graphql_schema.json` documenting the known myAir GraphQL fields and noting that standard introspection is not available.
- Added repository helper scripts for setup, lint, and test workflows, including automatic venv setup when needed.
- Ignored default live smoke-test env/output filenames and documented usage in the README.
- Added tests for env parsing, smoke-test output shaping, JSON writing, and shell helper behavior.

## Why
The integration depends on a reverse-engineered myAir API, so contributors need a lightweight way to confirm current live API behavior and inspect returned fields without running Home Assistant or committing credentials/output artifacts.

## Validation
- `./.venv/bin/python -m pytest`
- `./.venv/bin/prek run -a`
