### PR TITLE
Clean up myAir parsing and flow helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Developers can run a local smoke test against the live myAir API without Home As
 
 The script prompts for credentials when they are not provided. For repeatable local runs, create a `live_smoke_test.env` file using `live_smoke_test.env.example`.
 
-By default, output is written to `live_smoke_test_output.json` with the same fields shown in the sensor list above. Add `--raw` to include raw myAir payload values for local inspection. Known GraphQL types and fields are documented in `scripts/graphql_schema.json`.
+By default, output is written to `live_smoke_test_output.json` with the same fields shown in the sensor list above. Add `--raw` to include raw myAir payload values for local inspection. `scripts/graphql_schema.json` is a curated developer reference for observed GraphQL fields; it is not generated from endpoint introspection.
 
 ## Contributions are welcome!
 

--- a/custom_components/resmed_myair/client/auth.py
+++ b/custom_components/resmed_myair/client/auth.py
@@ -59,6 +59,50 @@ def _safe_auth_log_payload(data: Any) -> Any:
     return data
 
 
+def _mfa_challenge_metadata(
+    authn_dict: Mapping[str, Any], region_config: RegionConfig
+) -> tuple[str, str]:
+    """Resolve MFA factor metadata from an Okta authn response.
+
+    Args:
+        authn_dict: Decoded Okta authn response payload.
+        region_config: Regional endpoint configuration.
+
+    Returns:
+        Email factor ID and verification URL, falling back to regional defaults
+        when Okta omits factor metadata.
+    """
+    factor_id = region_config.email_factor_id
+    verify_url = region_config.mfa_url(factor_id)
+
+    embedded = authn_dict.get("_embedded")
+    if not isinstance(embedded, Mapping):
+        return factor_id, verify_url
+
+    factors = embedded.get("factors")
+    if not isinstance(factors, list) or not factors:
+        return factor_id, verify_url
+
+    factor = factors[0]
+    if not isinstance(factor, Mapping):
+        return factor_id, verify_url
+
+    authn_factor_id = factor.get("id")
+    if isinstance(authn_factor_id, str) and authn_factor_id:
+        factor_id = authn_factor_id
+        verify_url = region_config.mfa_url(factor_id)
+
+    links = factor.get("_links")
+    if isinstance(links, Mapping):
+        verify = links.get("verify")
+        if isinstance(verify, Mapping):
+            href = verify.get("href")
+            if isinstance(href, str) and href:
+                verify_url = f"{href}?rememberDevice=true"
+
+    return factor_id, verify_url
+
+
 class MyAirAuthSession:
     """Maintain Okta, OAuth, cookie, and token state for the myAir REST flow."""
 
@@ -508,18 +552,10 @@ class MyAirAuthSession:
             if "stateToken" not in authn_dict:
                 raise AuthenticationError("Cannot get stateToken in authn step")
             self._state_token = authn_dict["stateToken"]
-            try:
-                self._email_factor_id = authn_dict["_embedded"]["factors"][0]["id"]
-            except KeyError, TypeError:
-                self._email_factor_id = self._region_config.email_factor_id
+            self._email_factor_id, self._mfa_url = _mfa_challenge_metadata(
+                authn_dict, self._region_config
+            )
             _LOGGER.debug("[authn_check] email_factor_id: %s", self._email_factor_id)
-            try:
-                self._mfa_url = (
-                    f"{authn_dict['_embedded']['factors'][0]['_links']['verify']['href']}?"
-                    "rememberDevice=true"
-                )
-            except KeyError, TypeError:
-                self._mfa_url = self._region_config.mfa_url(self._email_factor_id)
             _LOGGER.debug("[authn_check] mfa_url: %s", self._mfa_url)
             _LOGGER.info("Initial Auth Completed. Needs MFA")
         elif status == AUTHN_SUCCESS:

--- a/custom_components/resmed_myair/client/auth.py
+++ b/custom_components/resmed_myair/client/auth.py
@@ -223,6 +223,8 @@ class MyAirAuthSession:
             value: Region configuration to use for subsequent auth requests.
         """
         self._region_config = value
+        self._email_factor_id = value.email_factor_id
+        self._mfa_url = value.mfa_url(self._email_factor_id)
 
     @property
     def email_factor_id(self) -> str:

--- a/custom_components/resmed_myair/client/rest_client.py
+++ b/custom_components/resmed_myair/client/rest_client.py
@@ -53,6 +53,36 @@ def _required_list(value: Any, message: str) -> list[Any]:
     return value
 
 
+def _optional_mask_code(patient_wrapper: Mapping[str, Any]) -> str | None:
+    """Extract a mask code from optional myAir mask metadata.
+
+    Args:
+        patient_wrapper: Decoded ``getPatientWrapper`` GraphQL payload.
+
+    Returns:
+        First non-empty mask code, or ``None`` when mask metadata is absent or malformed.
+    """
+    masks = patient_wrapper.get("masks")
+    if not isinstance(masks, list) or not masks:
+        _LOGGER.warning("Error getting User Mask Data. Missing or invalid masks payload")
+        return None
+
+    first_mask = masks[0]
+    if not isinstance(first_mask, Mapping):
+        _LOGGER.warning("Error getting User Mask Data. First mask is not a mapping")
+        return None
+
+    if "maskCode" not in first_mask:
+        _LOGGER.warning("Error getting User Mask Data. maskCode is missing")
+        return None
+
+    mask_code = first_mask.get("maskCode")
+    if mask_code and not isinstance(mask_code, str):
+        _LOGGER.warning("Error getting User Mask Data. maskCode is not a string")
+        return None
+    return mask_code or None
+
+
 class RESTClient(MyAirClient):
     """Coordinate myAir authentication and AppSync GraphQL data access."""
 
@@ -235,13 +265,7 @@ class RESTClient(MyAirClient):
                 devices[0], "Error getting User Device Data. Returned data is not a dict"
             )
         )
-        mask_code: str | None = None
-        try:
-            mask_code = patient_wrapper["masks"][0]["maskCode"]
-        except (KeyError, IndexError, TypeError) as e:
-            _LOGGER.warning("Error getting User Mask Data. %s: %s", type(e).__name__, e)
-        else:
-            if mask_code:
-                device["maskCode"] = mask_code
+        if mask_code := _optional_mask_code(patient_wrapper):
+            device["maskCode"] = mask_code
         _LOGGER.debug("[get_user_device_data] device: %s", redact_dict(device))
         return MyAirDevice.from_api(device)

--- a/custom_components/resmed_myair/client/rest_client.py
+++ b/custom_components/resmed_myair/client/rest_client.py
@@ -67,20 +67,26 @@ def _optional_mask_code(patient_wrapper: Mapping[str, Any]) -> str | None:
         _LOGGER.warning("Error getting User Mask Data. Missing or invalid masks payload")
         return None
 
-    first_mask = masks[0]
-    if not isinstance(first_mask, Mapping):
-        _LOGGER.warning("Error getting User Mask Data. First mask is not a mapping")
-        return None
+    found_malformed_mask = False
+    for mask in masks:
+        if not isinstance(mask, Mapping):
+            found_malformed_mask = True
+            continue
+        if "maskCode" not in mask:
+            found_malformed_mask = True
+            continue
 
-    if "maskCode" not in first_mask:
-        _LOGGER.warning("Error getting User Mask Data. maskCode is missing")
-        return None
+        mask_code = mask.get("maskCode")
+        if isinstance(mask_code, str):
+            if mask_code:
+                return mask_code
+            continue
 
-    mask_code = first_mask.get("maskCode")
-    if mask_code and not isinstance(mask_code, str):
-        _LOGGER.warning("Error getting User Mask Data. maskCode is not a string")
-        return None
-    return mask_code or None
+        found_malformed_mask = True
+
+    if found_malformed_mask:
+        _LOGGER.warning("Error getting User Mask Data. No valid maskCode found")
+    return None
 
 
 class RESTClient(MyAirClient):

--- a/custom_components/resmed_myair/config_flow.py
+++ b/custom_components/resmed_myair/config_flow.py
@@ -328,6 +328,35 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
             kwargs["unique_id"] = unique_id
         return self.async_update_reload_and_abort(entry, **kwargs)
 
+    def _finish_entry_update(
+        self,
+        entry: ConfigEntry,
+        *,
+        unique_id: str | None,
+        debug_message: str,
+        remove_mfa_code: bool = False,
+    ) -> ConfigFlowResult:
+        """Persist auth updates, reload the entry, and finish an update flow.
+
+        Args:
+            entry: Config entry being updated.
+            unique_id: Optional unique ID to backfill on legacy entries.
+            debug_message: Message used to log the redacted update payload.
+            remove_mfa_code: Whether to discard the submitted MFA code first.
+
+        Returns:
+            Home Assistant config-flow abort result with source-specific reason.
+        """
+        if remove_mfa_code:
+            self._data.pop(CONF_VERIFICATION_CODE, None)
+        self._store_device_token()
+        _LOGGER.debug(debug_message, redact_dict(self._data))
+        return self._update_reload_and_abort(
+            entry,
+            data_updates={**self._data},
+            unique_id=unique_id,
+        )
+
     async def _async_abort_incomplete_account(
         self, step: str, error: IncompleteAccountError
     ) -> ConfigFlowResult:
@@ -503,14 +532,11 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                         return mismatch_abort
                     serial_number: str = device.serial_number
                     _LOGGER.info("Found device with serial number %s", serial_number)
-                    self._store_device_token()
-                    _LOGGER.debug("[async_step_reauth_confirm] data: %s", redact_dict(self._data))
-
                     unique_id = device.serial_number if not self._entry.unique_id else None
-                    return self._update_reload_and_abort(
+                    return self._finish_entry_update(
                         self._entry,
-                        data_updates={**self._data},
                         unique_id=unique_id,
+                        debug_message="[async_step_reauth_confirm] data: %s",
                     )
                 return await self.async_step_reauth_verify_mfa()
             except CONNECTION_ERRORS as e:
@@ -549,17 +575,12 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                 if status == AUTHN_SUCCESS:
                     if mismatch_abort := self._abort_if_reauth_device_mismatch(device):
                         return mismatch_abort
-                    self._data.pop(CONF_VERIFICATION_CODE, None)
-                    self._store_device_token()
-                    _LOGGER.debug(
-                        "[async_step_reauth_verify_mfa] user_input: %s", redact_dict(self._data)
-                    )
-
                     unique_id = device.serial_number if not self._entry.unique_id else None
-                    return self._update_reload_and_abort(
+                    return self._finish_entry_update(
                         self._entry,
-                        data_updates={**self._data},
                         unique_id=unique_id,
+                        debug_message="[async_step_reauth_verify_mfa] user_input: %s",
+                        remove_mfa_code=True,
                     )
                 _LOGGER.error("Issue verifying MFA. Status: %s", status)
                 errors["base"] = "mfa_error"
@@ -601,12 +622,10 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                     )
                     if identity_abort:
                         return identity_abort
-                    self._store_device_token()
-                    _LOGGER.debug("[async_step_reconfigure] data: %s", redact_dict(self._data))
-                    return self._update_reload_and_abort(
+                    return self._finish_entry_update(
                         entry,
-                        data_updates={**self._data},
                         unique_id=unique_id,
+                        debug_message="[async_step_reconfigure] data: %s",
                     )
                 return await self.async_step_reconfigure_verify_mfa()
             except CONNECTION_ERRORS as e:
@@ -647,16 +666,11 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                     )
                     if identity_abort:
                         return identity_abort
-                    self._data.pop(CONF_VERIFICATION_CODE, None)
-                    self._store_device_token()
-                    _LOGGER.debug(
-                        "[async_step_reconfigure_verify_mfa] data: %s",
-                        redact_dict(self._data),
-                    )
-                    return self._update_reload_and_abort(
+                    return self._finish_entry_update(
                         entry,
-                        data_updates={**self._data},
                         unique_id=unique_id,
+                        debug_message="[async_step_reconfigure_verify_mfa] data: %s",
+                        remove_mfa_code=True,
                     )
                 _LOGGER.error("Issue verifying MFA. Status: %s", status)
                 errors["base"] = "mfa_error"

--- a/custom_components/resmed_myair/config_flow.py
+++ b/custom_components/resmed_myair/config_flow.py
@@ -204,6 +204,25 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
             }
         )
 
+    def _show_mfa_form(self, step_id: str, errors: Mapping[str, str]) -> ConfigFlowResult:
+        """Show an MFA verification form with the shared account placeholder.
+
+        Args:
+            step_id: Config-flow step that should receive the submitted MFA code.
+            errors: Form errors accumulated while handling the step.
+
+        Returns:
+            Home Assistant form result for the requested MFA step.
+        """
+        return self.async_show_form(
+            step_id=step_id,
+            data_schema=self._mfa_schema(),
+            description_placeholders={
+                "username": self._data.get(CONF_USER_NAME, "your email address"),
+            },
+            errors=dict(errors),
+        )
+
     def _entry_title(self, device: MyAirDevice) -> str:
         """Build a stable Home Assistant entry title from device metadata.
 
@@ -434,14 +453,7 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                 return await self._async_abort_incomplete_account("verify_mfa", e)
 
         _LOGGER.info("Showing Verify MFA Form")
-        return self.async_show_form(
-            step_id="verify_mfa",
-            data_schema=self._mfa_schema(),
-            description_placeholders={
-                "username": self._data.get(CONF_USER_NAME, "your email address"),
-            },
-            errors=errors,
-        )
+        return self._show_mfa_form("verify_mfa", errors)
 
     async def async_step_reauth(self, entry_data: MutableMapping[str, Any]) -> ConfigFlowResult:
         """Load the existing config entry before prompting for new credentials.
@@ -558,14 +570,7 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                 return await self._async_abort_incomplete_account("reauth_verify_mfa", e)
 
         _LOGGER.info("Showing Reauth Verify MFA Form")
-        return self.async_show_form(
-            step_id="reauth_verify_mfa",
-            data_schema=self._mfa_schema(),
-            description_placeholders={
-                "username": self._data.get(CONF_USER_NAME, "your email address"),
-            },
-            errors=errors,
-        )
+        return self._show_mfa_form("reauth_verify_mfa", errors)
 
     async def async_step_reconfigure(
         self, user_input: MutableMapping[str, Any] | None = None
@@ -666,11 +671,4 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                 return await self._async_abort_incomplete_account("reconfigure_verify_mfa", e)
 
         _LOGGER.info("Showing Reconfigure Verify MFA Form")
-        return self.async_show_form(
-            step_id="reconfigure_verify_mfa",
-            data_schema=self._mfa_schema(),
-            description_placeholders={
-                "username": self._data.get(CONF_USER_NAME, "your email address"),
-            },
-            errors=errors,
-        )
+        return self._show_mfa_form("reconfigure_verify_mfa", errors)

--- a/custom_components/resmed_myair/config_flow.py
+++ b/custom_components/resmed_myair/config_flow.py
@@ -36,12 +36,15 @@ from .models import MyAirDevice
 from .redaction import redact_dict
 
 _LOGGER = logging.getLogger(__name__)
-EMAIL_VERIFICATION_ERRORS: tuple[type[Exception], ...] = (
+CONNECTION_ERRORS: tuple[type[Exception], ...] = (
     AuthenticationError,
     HttpProcessingError,
-    ClientError,
     ClientResponseError,
     ParsingError,
+)
+EMAIL_VERIFICATION_ERRORS: tuple[type[Exception], ...] = (
+    *CONNECTION_ERRORS,
+    ClientError,
     TimeoutError,
     ValueError,
 )
@@ -377,12 +380,7 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                         data=self._data,
                     )
                 return await self.async_step_verify_mfa()
-            except (
-                AuthenticationError,
-                HttpProcessingError,
-                ClientResponseError,
-                ParsingError,
-            ) as e:
+            except CONNECTION_ERRORS as e:
                 _LOGGER.error("Connection Error at async_step_user. %s: %s", type(e).__name__, e)
                 errors["base"] = "authentication_error"
             except IncompleteAccountError as e:
@@ -429,12 +427,7 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                     )
                 _LOGGER.error("Issue verifying MFA. Status: %s", status)
                 errors["base"] = "mfa_error"
-            except (
-                AuthenticationError,
-                HttpProcessingError,
-                ClientResponseError,
-                ParsingError,
-            ) as e:
+            except CONNECTION_ERRORS as e:
                 _LOGGER.error("Connection Error at verify_mfa. %s: %s", type(e).__name__, e)
                 errors["base"] = "mfa_error"
             except IncompleteAccountError as e:
@@ -508,12 +501,7 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                         unique_id=unique_id,
                     )
                 return await self.async_step_reauth_verify_mfa()
-            except (
-                AuthenticationError,
-                HttpProcessingError,
-                ClientResponseError,
-                ParsingError,
-            ) as e:
+            except CONNECTION_ERRORS as e:
                 _LOGGER.error("Connection Error at reauth_confirm. %s: %s", type(e).__name__, e)
                 errors["base"] = "authentication_error"
             except IncompleteAccountError as e:
@@ -563,12 +551,7 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                     )
                 _LOGGER.error("Issue verifying MFA. Status: %s", status)
                 errors["base"] = "mfa_error"
-            except (
-                AuthenticationError,
-                HttpProcessingError,
-                ClientResponseError,
-                ParsingError,
-            ) as e:
+            except CONNECTION_ERRORS as e:
                 _LOGGER.error("Connection Error at reauth_verify_mfa. %s: %s", type(e).__name__, e)
                 errors["base"] = "mfa_error"
             except IncompleteAccountError as e:
@@ -621,12 +604,7 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                         unique_id=unique_id,
                     )
                 return await self.async_step_reconfigure_verify_mfa()
-            except (
-                AuthenticationError,
-                HttpProcessingError,
-                ClientResponseError,
-                ParsingError,
-            ) as e:
+            except CONNECTION_ERRORS as e:
                 _LOGGER.error("Connection Error at reconfigure. %s: %s", type(e).__name__, e)
                 errors["base"] = "authentication_error"
             except IncompleteAccountError as e:
@@ -677,12 +655,7 @@ class MyAirConfigFlow(ConfigFlow, domain=DOMAIN):
                     )
                 _LOGGER.error("Issue verifying MFA. Status: %s", status)
                 errors["base"] = "mfa_error"
-            except (
-                AuthenticationError,
-                HttpProcessingError,
-                ClientResponseError,
-                ParsingError,
-            ) as e:
+            except CONNECTION_ERRORS as e:
                 _LOGGER.error(
                     "Connection Error at reconfigure_verify_mfa. %s: %s",
                     type(e).__name__,

--- a/custom_components/resmed_myair/coordinator.py
+++ b/custom_components/resmed_myair/coordinator.py
@@ -67,12 +67,20 @@ class MyAirDataUpdateCoordinator(DataUpdateCoordinator[MyAirCoordinatorData]):
 
         try:
             device = await self.myair_client.get_user_device_data()
-        except ParsingError:
-            _LOGGER.debug("Device data unavailable in myAir update")
+        except ParsingError as err:
+            _LOGGER.debug(
+                "Device data unavailable in myAir update. %s: %s",
+                type(err).__name__,
+                err,
+            )
 
         try:
             sleep_records = tuple(await self.myair_client.get_sleep_records())
-        except ParsingError:
-            _LOGGER.debug("Sleep record data unavailable in myAir update")
+        except ParsingError as err:
+            _LOGGER.debug(
+                "Sleep record data unavailable in myAir update. %s: %s",
+                type(err).__name__,
+                err,
+            )
 
         return MyAirCoordinatorData(device=device, sleep_records=sleep_records)

--- a/custom_components/resmed_myair/models.py
+++ b/custom_components/resmed_myair/models.py
@@ -189,9 +189,11 @@ class MyAirCoordinatorData:
         Returns:
             Most recent record, or ``None`` when the coordinator has no records.
         """
-        if not self.sleep_records:
-            return None
-        return max(self.sleep_records, key=lambda record: record.start_date or date.min)
+        return max(
+            self.sleep_records,
+            key=lambda record: record.start_date or date.min,
+            default=None,
+        )
 
     @property
     def most_recent_sleep_date(self) -> date | None:
@@ -200,9 +202,11 @@ class MyAirCoordinatorData:
         Returns:
             Date of the most recent usage-bearing record, or ``None`` if none qualify.
         """
-        records_with_usage = [
-            record for record in self.sleep_records if record.start_date and record.has_usage
-        ]
-        if not records_with_usage:
-            return None
-        return max(records_with_usage, key=lambda record: record.start_date or date.min).start_date
+        return max(
+            (
+                record.start_date
+                for record in self.sleep_records
+                if record.start_date and record.has_usage
+            ),
+            default=None,
+        )

--- a/custom_components/resmed_myair/sensor.py
+++ b/custom_components/resmed_myair/sensor.py
@@ -1,5 +1,6 @@
 """Home Assistant sensor entities for ResMed myAir account data."""
 
+from abc import abstractmethod
 from datetime import date
 import logging
 import re
@@ -120,9 +121,6 @@ async def async_setup_entry(
 class MyAirBaseSensor(CoordinatorEntity[MyAirDataUpdateCoordinator], SensorEntity):
     """Base entity for sensors that share myAir device identity and availability."""
 
-    _missing_source_log: str = "Sensor data missing from coordinator data"
-    _parse_error_source: str = "Sensor"
-
     def __init__(
         self,
         friendly_name: str,
@@ -169,25 +167,21 @@ class MyAirBaseSensor(CoordinatorEntity[MyAirDataUpdateCoordinator], SensorEntit
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
+
+class MyAirRawSensor(MyAirBaseSensor):
+    """Base entity for sensors that read a raw API field from a model payload."""
+
+    _missing_source_log: str = "Sensor data missing from coordinator data"
+    _parse_error_source: str = "Sensor"
+
+    @abstractmethod
     def _sensor_payload(self) -> _SensorPayload | None:
         """Return the model object that contains this sensor's raw API field.
-
-        This partial implementation raises ``NotImplementedError`` and exists for
-        sensors that use coordinator-provided device or sleep-record models with
-        the base ``_handle_coordinator_update`` implementation. Subclasses with
-        fully custom update logic, such as ``MyAirFriendlyUsageTime`` and
-        ``MyAirMostRecentSleepDate``, may intentionally skip this method and parse
-        coordinator payloads directly in their own ``_handle_coordinator_update``.
 
         Returns:
             Device or sleep-record model for raw GraphQL-backed sensors, or ``None``
             when the coordinator did not receive the required payload.
-
-        Raises:
-            NotImplementedError: If a subclass uses the base update handler without
-                implementing this payload selector.
         """
-        raise NotImplementedError
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -216,7 +210,7 @@ class MyAirBaseSensor(CoordinatorEntity[MyAirDataUpdateCoordinator], SensorEntit
         self.async_write_ha_state()
 
 
-class MyAirSleepRecordSensor(MyAirBaseSensor):
+class MyAirSleepRecordSensor(MyAirRawSensor):
     """Expose a configured GraphQL field from the newest nightly sleep record."""
 
     _missing_source_log = "Sleep record data missing from coordinator data"
@@ -234,7 +228,7 @@ class MyAirSleepRecordSensor(MyAirBaseSensor):
         return _coordinator_data(self.coordinator).latest_sleep_record
 
 
-class MyAirDeviceSensor(MyAirBaseSensor):
+class MyAirDeviceSensor(MyAirRawSensor):
     """Expose a configured GraphQL field from the assigned CPAP device payload."""
 
     _missing_source_log = "Device data missing from coordinator data"

--- a/scripts/graphql_schema.json
+++ b/scripts/graphql_schema.json
@@ -1,5 +1,11 @@
 {
+  "purpose": "Curated developer reference for myAir GraphQL fields observed while maintaining this integration.",
   "source": "Manual schema notes from working integration queries and validation probes.",
+  "maintenance": {
+    "generated": false,
+    "authoritative": false,
+    "update_process": "Update manually when live smoke-test output, validation probes, or integration query changes confirm a field shape."
+  },
   "introspection": {
     "available": false,
     "notes": [

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
 """Coordinator tests that protect refresh, auth, and parse fallbacks."""
 
+import logging
 from unittest.mock import MagicMock
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -57,7 +58,10 @@ async def test_async_update_data_auth_error(hass: MagicMock, myair_client: Magic
 @pytest.mark.parametrize("failing_fetch", ["device", "sleep_records"])
 @pytest.mark.asyncio
 async def test_async_update_data_parsing_error_variants(
-    hass: MagicMock, myair_client: MagicMock, failing_fetch: str
+    hass: MagicMock,
+    myair_client: MagicMock,
+    failing_fetch: str,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Parsing failures degrade only the failing payload branch."""
     expected_device = MyAirDevice.from_api(
@@ -73,14 +77,23 @@ async def test_async_update_data_parsing_error_variants(
         myair_client.get_sleep_records.side_effect = ParsingError("sleep parse fail")
 
     coordinator = MyAirDataUpdateCoordinator(hass, MagicMock(), myair_client)
-    data = await coordinator._async_update_data()
+    with caplog.at_level(logging.DEBUG):
+        data = await coordinator._async_update_data()
 
     if failing_fetch == "device":
         assert data.device is None
         assert data.sleep_records == expected_records
+        assert (
+            "Device data unavailable in myAir update. ParsingError: device parse fail"
+            in caplog.text
+        )
     else:
         assert data.device is expected_device
         assert data.sleep_records == ()
+        assert (
+            "Sleep record data unavailable in myAir update. ParsingError: sleep parse fail"
+            in caplog.text
+        )
 
     myair_client.connect.assert_awaited_once()
     myair_client.get_user_device_data.assert_awaited_once()

--- a/tests/test_graphql_schema.py
+++ b/tests/test_graphql_schema.py
@@ -1,0 +1,21 @@
+"""Tests for the curated GraphQL schema reference."""
+
+import json
+from pathlib import Path
+
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "scripts" / "graphql_schema.json"
+
+
+def test_graphql_schema_declares_manual_reference_status() -> None:
+    """Schema notes are clearly marked as manual, non-authoritative reference data."""
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    assert schema["maintenance"] == {
+        "generated": False,
+        "authoritative": False,
+        "update_process": (
+            "Update manually when live smoke-test output, validation probes, or integration "
+            "query changes confirm a field shape."
+        ),
+    }
+    assert schema["introspection"]["available"] is False

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -1285,6 +1285,10 @@ async def test_get_user_device_data_failure_variants(
         ([{"maskCode": "MASK123"}], False, "MASK123"),
         ([{"maskCode": ""}], False, None),
         ([], True, None),
+        ("not-a-list", True, None),
+        ([123], True, None),
+        ([{}], True, None),
+        ([{"maskCode": 123}], True, None),
     ],
 )
 async def test_get_user_device_data_masks_variants(

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -11,7 +11,7 @@ from multidict import CIMultiDict
 import pytest
 
 from custom_components.resmed_myair.client import rest_client as rest_client_module
-from custom_components.resmed_myair.client.auth import MyAirAuthSession
+from custom_components.resmed_myair.client.auth import MyAirAuthSession, _mfa_challenge_metadata
 from custom_components.resmed_myair.client.graphql import MyAirGraphQLClient
 from custom_components.resmed_myair.client.myair_client import (
     AuthenticationError,
@@ -106,6 +106,8 @@ def test_rest_client_init_region(
     ("property_name", "new_value"),
     [
         ("json_headers", {"Accept": "application/json"}),
+        ("region_config", EU_CONFIG),
+        ("email_factor_id", "email-factor-id"),
     ],
 )
 def test_auth_session_property_variants(
@@ -120,6 +122,47 @@ def test_auth_session_property_variants(
     setattr(auth, property_name, new_value)
 
     assert getattr(auth, property_name) == new_value
+
+
+@pytest.mark.parametrize(
+    ("authn_dict", "expected_factor_id", "expected_mfa_url"),
+    [
+        ({}, NA_CONFIG.email_factor_id, NA_CONFIG.mfa_url(NA_CONFIG.email_factor_id)),
+        (
+            {"_embedded": {"factors": "not-a-list"}},
+            NA_CONFIG.email_factor_id,
+            NA_CONFIG.mfa_url(NA_CONFIG.email_factor_id),
+        ),
+        (
+            {"_embedded": {"factors": []}},
+            NA_CONFIG.email_factor_id,
+            NA_CONFIG.mfa_url(NA_CONFIG.email_factor_id),
+        ),
+        (
+            {"_embedded": {"factors": [None]}},
+            NA_CONFIG.email_factor_id,
+            NA_CONFIG.mfa_url(NA_CONFIG.email_factor_id),
+        ),
+        (
+            {"_embedded": {"factors": [{"id": "factor-id", "_links": None}]}},
+            "factor-id",
+            NA_CONFIG.mfa_url("factor-id"),
+        ),
+        (
+            {"_embedded": {"factors": [{"id": "factor-id", "_links": {"verify": None}}]}},
+            "factor-id",
+            NA_CONFIG.mfa_url("factor-id"),
+        ),
+    ],
+)
+def test_mfa_challenge_metadata_handles_partial_okta_payloads(
+    authn_dict: dict[str, object], expected_factor_id: str, expected_mfa_url: str
+) -> None:
+    """MFA metadata parsing keeps regional defaults unless Okta supplies valid fields."""
+    assert _mfa_challenge_metadata(authn_dict, NA_CONFIG) == (
+        expected_factor_id,
+        expected_mfa_url,
+    )
 
 
 @pytest.mark.parametrize("case", ["device_token", "cookies"])

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -1376,24 +1376,31 @@ async def test_resmed_response_error_check_not_bad_request() -> None:
 @pytest.mark.parametrize(
     "authn_dict",
     [
-        # KeyError: _embedded missing
         {
             "status": "MFA_REQUIRED",
             "stateToken": "token123",
-            # '_embedded' missing
         },
-        # TypeError: _embedded is not subscriptable
         {
             "status": "MFA_REQUIRED",
             "stateToken": "token123",
             "_embedded": None,
         },
+        {
+            "status": "MFA_REQUIRED",
+            "stateToken": "token123",
+            "_embedded": {"factors": [{"id": "", "_links": {"verify": {"href": ""}}}]},
+        },
+        {
+            "status": "MFA_REQUIRED",
+            "stateToken": "token123",
+            "_embedded": {"factors": [{"id": 123, "_links": {"verify": {"href": 456}}}]},
+        },
     ],
 )
-async def test_authn_check_email_factor_id_exceptions(
+async def test_authn_check_uses_region_mfa_defaults_for_malformed_factor_metadata(
     authn_dict: object, session: MagicMock, config_na: MyAirConfig
 ) -> None:
-    """Auth checks fall back to the region email-factor ID on lookup errors."""
+    """Auth checks fall back to regional MFA metadata when Okta omits factor details."""
     # MyAirConfig is a NamedTuple (immutable) so use _replace to change device_token
     config = config_na._replace(device_token=None)
     client = RESTClient(config, session)
@@ -1402,9 +1409,11 @@ async def test_authn_check_email_factor_id_exceptions(
     mock_response = make_mock_aiohttp_response(json_value=authn_dict)
     session.post.return_value = make_mock_aiohttp_context_manager(mock_response)
 
-    # Should NOT raise, but should set _email_factor_id to region_config.email_factor_id
     result = await client._auth._authn_check()
     assert client._auth.email_factor_id == client._auth.region_config.email_factor_id
+    assert client._auth.mfa_url == client._auth.region_config.mfa_url(
+        client._auth.region_config.email_factor_id
+    )
     assert result == "MFA_REQUIRED"
 
 

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -122,6 +122,10 @@ def test_auth_session_property_variants(
     setattr(auth, property_name, new_value)
 
     assert getattr(auth, property_name) == new_value
+    if property_name == "region_config":
+        assert isinstance(new_value, RegionConfig)
+        assert auth.email_factor_id == new_value.email_factor_id
+        assert auth.mfa_url == new_value.mfa_url(new_value.email_factor_id)
 
 
 @pytest.mark.parametrize(
@@ -1327,6 +1331,8 @@ async def test_get_user_device_data_failure_variants(
     [
         ([{"maskCode": "MASK123"}], False, "MASK123"),
         ([{"maskCode": ""}], False, None),
+        ([{}, {"maskCode": "MASK123"}], False, "MASK123"),
+        ([{"maskCode": ""}, {"maskCode": "MASK123"}], False, "MASK123"),
         ([], True, None),
         ("not-a-list", True, None),
         ([123], True, None),


### PR DESCRIPTION
## Summary
Tightens the myAir integration cleanup work around API parsing, config-flow completion paths, and sensor/coordinator data handling without changing user-facing behavior. The branch removes repeated code paths, makes preserved compatibility behavior explicit, and clarifies the GraphQL schema snapshot as a manual reference artifact.

## What Changed
- Made mask payload parsing explicit in the REST client and added coverage for malformed or missing payload shapes.
- Preserved partial coordinator refresh behavior while logging parse failures with useful evidence.
- Split raw sensor payload handling into a shared base and simplified coordinator date selection.
- Consolidated config-flow connection errors, MFA form creation, MFA metadata parsing, and config-entry update completion helpers.
- Documented the GraphQL schema snapshot as a manual, non-authoritative reference and covered that status in tests.

## Why
This cleanup reduces repeated helper logic and fallback-looking branches that made the integration harder to review. The preserved compatibility and fail-safe paths remain covered by tests, while parsing and flow completion code now states its assumptions more directly.

## Related Issues
N/A