### PR TITLE
Migrate prek autoupdate workflow configuration

### DIFF
--- a/.github/workflows/prek_autoupdate.yml
+++ b/.github/workflows/prek_autoupdate.yml
@@ -2,7 +2,10 @@ name: prek Autoupdate
 
 on:
   schedule:
-    - cron: '11 7 * * *'
+    - cron: '0 7 * * *'
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -11,10 +14,5 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write
     with:
       update-day: "2"
-      dispatch-workflows: |
-        linters.yml
-        pytest_coverage.yml
-        validate.yml


### PR DESCRIPTION
## Summary

Migrates the prek autoupdate caller to the current reusable workflow configuration and keeps updates aligned with the repository's main branch.

## What Changed

- Run the scheduled update at 07:00 UTC and trigger the workflow when `main` changes
- Remove the no-longer-needed `actions: write` permission
- Remove downstream workflow dispatch inputs from the reusable workflow call

## Why

This keeps the repository's autoupdate workflow compatible with the reusable `Snuffy2/prek-autoupdate@v1` interface while simplifying the caller configuration.