### PR TITLE
Retry stale myAir sessions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: true
+blank_issues_enabled: false

--- a/custom_components/resmed_myair/client/auth.py
+++ b/custom_components/resmed_myair/client/auth.py
@@ -301,12 +301,13 @@ class MyAirAuthSession:
         """
         self._json_headers = dict(value)
 
-    async def connect(self, initial: bool | None = False) -> str:
+    async def connect(self, initial: bool | None = False, *, force: bool = False) -> str:
         """Authenticate or reuse existing credentials for a myAir session.
 
         Args:
             initial (bool | None): Whether this is the first config-flow attempt, when MFA may be
                 triggered instead of reported as a reauth failure.
+            force (bool): Whether to bypass token introspection and authenticate again.
 
         Returns:
             str: Okta auth status, such as ``SUCCESS`` or ``MFA_REQUIRED``.
@@ -318,8 +319,10 @@ class MyAirAuthSession:
             await self._get_initial_dt()
         if self._cookie_dt is None and self._uses_mfa:
             _LOGGER.warning("Device Token isn't set. This will require frequent reauthentication.")
-        if self._access_token and await self._is_access_token_active():
+        if self._access_token and not force and await self._is_access_token_active():
             return AUTHN_SUCCESS
+        if force:
+            _LOGGER.info("Forcing fresh authentication")
         _LOGGER.info("Starting Authentication")
         status: str = await self._authn_check()
         if status == AUTH_NEEDS_MFA:

--- a/custom_components/resmed_myair/client/auth.py
+++ b/custom_components/resmed_myair/client/auth.py
@@ -19,7 +19,13 @@ from multidict import CIMultiDict
 from custom_components.resmed_myair.const import AUTH_NEEDS_MFA, AUTHN_SUCCESS
 from custom_components.resmed_myair.redaction import redact_dict
 
-from .myair_client import AuthenticationError, IncompleteAccountError, MyAirConfig, ParsingError
+from .myair_client import (
+    AuthenticationError,
+    IncompleteAccountError,
+    MyAirConfig,
+    ParsingError,
+    StaleSessionError,
+)
 from .regions import RegionConfig, get_region_config
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -491,7 +497,7 @@ class MyAirAuthSession:
         Raises:
             AuthenticationError: When credentials or auth state are rejected.
             IncompleteAccountError: When myAir reports account setup is incomplete.
-            ParsingError: When a non-initial GraphQL request becomes unauthorized.
+            StaleSessionError: When a non-initial GraphQL request becomes unauthorized.
             HttpProcessingError: When a structured error exists but has no typed mapping.
         """
         if "errors" in resp_dict:
@@ -503,7 +509,7 @@ class MyAirAuthSession:
                     )
                     if resp_dict["errors"][0]["errorInfo"]["errorType"] == "unauthorized":
                         if step == "gql_query" and not initial:
-                            raise ParsingError(
+                            raise StaleSessionError(
                                 f"Getting unauthorized error on {step} step. {error_message}"
                             )
                         raise AuthenticationError(

--- a/custom_components/resmed_myair/client/myair_client.py
+++ b/custom_components/resmed_myair/client/myair_client.py
@@ -31,8 +31,13 @@ class MyAirClient(ABC):
     """Abstract async contract consumed by the Home Assistant coordinator."""
 
     @abstractmethod
-    async def connect(self) -> str:
+    async def connect(self, initial: bool | None = False, *, force: bool = False) -> str:
         """Authenticate or validate cached credentials before data fetches.
+
+        Args:
+            initial (bool | None): Whether authentication is part of initial setup.
+            force (bool): Whether to bypass cached-token validation and authenticate
+                again.
 
         Returns:
             str: Provider-specific auth status string.

--- a/custom_components/resmed_myair/client/myair_client.py
+++ b/custom_components/resmed_myair/client/myair_client.py
@@ -18,6 +18,10 @@ class ParsingError(Exception):
     """Remote payload shape does not match the fields this integration requires."""
 
 
+class StaleSessionError(ParsingError):
+    """Remote response indicates the data API no longer accepts the session."""
+
+
 class MyAirConfig(NamedTuple):
     """Credentials and regional context needed to authenticate with myAir."""
 

--- a/custom_components/resmed_myair/client/rest_client.py
+++ b/custom_components/resmed_myair/client/rest_client.py
@@ -12,7 +12,7 @@ from custom_components.resmed_myair.redaction import redact_dict
 
 from .auth import MyAirAuthSession
 from .graphql import MyAirGraphQLClient
-from .myair_client import MyAirClient, MyAirConfig, ParsingError
+from .myair_client import MyAirClient, MyAirConfig, ParsingError, StaleSessionError
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -35,19 +35,43 @@ def _required_mapping(value: Any, message: str) -> Mapping[str, Any]:
     return value
 
 
-def _required_list(value: Any, message: str) -> list[Any]:
-    """Validate that a decoded GraphQL payload member is a JSON array.
+def _required_session_mapping(value: Any, message: str) -> Mapping[str, Any]:
+    """Validate a required mapping and mark an absent member as a stale session.
 
     Args:
-        value (Any): Payload member to validate.
-        message (str): Parsing error message to raise when validation fails.
+        value (Any): Required response member to validate.
+        message (str): Parsing error message raised for an invalid member.
 
     Returns:
-        list[Any]: The validated payload member.
+        Mapping[str, Any]: The validated response member.
 
     Raises:
-        ParsingError: When the payload member is not a list.
+        StaleSessionError: When the required response member is absent.
+        ParsingError: When the response member is present but malformed.
     """
+    if value is None:
+        raise StaleSessionError(message)
+    if not isinstance(value, Mapping):
+        raise ParsingError(message)
+    return value
+
+
+def _required_session_list(value: Any, message: str) -> list[Any]:
+    """Validate a required list and mark an absent member as a stale session.
+
+    Args:
+        value (Any): Required response member to validate.
+        message (str): Parsing error message raised for an invalid member.
+
+    Returns:
+        list[Any]: The validated response member.
+
+    Raises:
+        StaleSessionError: When the required response member is absent.
+        ParsingError: When the response member is present but malformed.
+    """
+    if value is None:
+        raise StaleSessionError(message)
     if not isinstance(value, list):
         raise ParsingError(message)
     return value
@@ -212,14 +236,16 @@ class RESTClient(MyAirClient):
             "GetPatientSleepRecords", query, initial
         )
         _LOGGER.debug("[get_sleep_records] records_dict: %s", redact_dict(records_dict))
-        data = _required_mapping(records_dict.get("data"), "Error getting Patient Sleep Records")
-        patient_wrapper = _required_mapping(
+        data = _required_session_mapping(
+            records_dict.get("data"), "Error getting Patient Sleep Records"
+        )
+        patient_wrapper = _required_session_mapping(
             data.get("getPatientWrapper"), "Error getting Patient Sleep Records"
         )
-        sleep_records = _required_mapping(
+        sleep_records = _required_session_mapping(
             patient_wrapper.get("sleepRecords"), "Error getting Patient Sleep Records"
         )
-        records = _required_list(
+        records = _required_session_list(
             sleep_records.get("items"),
             "Error getting Patient Sleep Records. Returned records is not a list",
         )
@@ -272,11 +298,13 @@ class RESTClient(MyAirClient):
             "getPatientWrapper", query, initial
         )
         _LOGGER.debug("[get_user_device_data] records_dict: %s", redact_dict(records_dict))
-        data = _required_mapping(records_dict.get("data"), "Error getting User Device Data")
-        patient_wrapper = _required_mapping(
+        data = _required_session_mapping(records_dict.get("data"), "Error getting User Device Data")
+        patient_wrapper = _required_session_mapping(
             data.get("getPatientWrapper"), "Error getting User Device Data"
         )
-        devices = _required_list(patient_wrapper.get("fgDevices"), "Error getting User Device Data")
+        devices = _required_session_list(
+            patient_wrapper.get("fgDevices"), "Error getting User Device Data"
+        )
         if not devices:
             raise ParsingError("Error getting User Device Data")
         device = dict(

--- a/custom_components/resmed_myair/client/rest_client.py
+++ b/custom_components/resmed_myair/client/rest_client.py
@@ -115,17 +115,19 @@ class RESTClient(MyAirClient):
         """Expose the remembered-device token that should be saved in config entries."""
         return self._auth.device_token
 
-    async def connect(self, initial: bool | None = False) -> str:
+    async def connect(self, initial: bool | None = False, *, force: bool = False) -> str:
         """Authenticate with myAir or reuse an active OAuth token.
 
         Args:
             initial (bool | None): Whether the call is part of config setup, where MFA can be
                 triggered and surfaced to the user.
+            force (bool): Whether to bypass cached-token validation and authenticate
+                again.
 
         Returns:
             str: Okta authentication status.
         """
-        return await self._auth.connect(initial=initial)
+        return await self._auth.connect(initial=initial, force=force)
 
     async def verify_mfa_and_get_access_token(self, verification_code: str) -> str:
         """Complete an MFA challenge and cache OAuth tokens.

--- a/custom_components/resmed_myair/coordinator.py
+++ b/custom_components/resmed_myair/coordinator.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .client.myair_client import AuthenticationError, MyAirClient, ParsingError
+from .client.myair_client import AuthenticationError, MyAirClient, ParsingError, StaleSessionError
 from .const import DEFAULT_UPDATE_RATE_MIN
 from .models import MyAirCoordinatorData, MyAirDevice, MyAirSleepRecord
 
@@ -58,19 +58,19 @@ class MyAirDataUpdateCoordinator(DataUpdateCoordinator[MyAirCoordinatorData]):
 
         device: MyAirDevice | None = None
         sleep_records: tuple[MyAirSleepRecord, ...] = ()
+        fresh_auth_used = False
 
         try:
             device = await self.myair_client.get_user_device_data()
-        except ParsingError as err:
-            _LOGGER.debug(
-                "Device data unavailable in myAir update. %s: %s",
+        except StaleSessionError as err:
+            _LOGGER.info(
+                "Device payload missing after token validation. %s: %s",
                 type(err).__name__,
                 err,
             )
-            _LOGGER.info(
-                "Device payload missing after token validation; retrying with fresh authentication"
-            )
+            _LOGGER.info("Retrying device data with fresh authentication")
             await self._async_connect(force=True)
+            fresh_auth_used = True
             try:
                 device = await self.myair_client.get_user_device_data()
             except ParsingError as retry_err:
@@ -79,9 +79,32 @@ class MyAirDataUpdateCoordinator(DataUpdateCoordinator[MyAirCoordinatorData]):
                     type(retry_err).__name__,
                     retry_err,
                 )
+        except ParsingError as err:
+            _LOGGER.debug(
+                "Device data unavailable in myAir update. %s: %s",
+                type(err).__name__,
+                err,
+            )
 
         try:
             sleep_records = tuple(await self.myair_client.get_sleep_records())
+        except StaleSessionError as err:
+            _LOGGER.info(
+                "Sleep record payload missing after token validation. %s: %s",
+                type(err).__name__,
+                err,
+            )
+            if not fresh_auth_used:
+                _LOGGER.info("Retrying sleep record data with fresh authentication")
+                await self._async_connect(force=True)
+                try:
+                    sleep_records = tuple(await self.myair_client.get_sleep_records())
+                except ParsingError as retry_err:
+                    _LOGGER.debug(
+                        "Sleep record data unavailable after fresh authentication. %s: %s",
+                        type(retry_err).__name__,
+                        retry_err,
+                    )
         except ParsingError as err:
             _LOGGER.debug(
                 "Sleep record data unavailable in myAir update. %s: %s",

--- a/custom_components/resmed_myair/coordinator.py
+++ b/custom_components/resmed_myair/coordinator.py
@@ -51,19 +51,10 @@ class MyAirDataUpdateCoordinator(DataUpdateCoordinator[MyAirCoordinatorData]):
         Returns:
             MyAirCoordinatorData: Typed coordinator payload containing any data
                 available from myAir.
-
-        Raises:
-            ConfigEntryAuthFailed: When myAir authentication must be repaired by reauth.
         """
         _LOGGER.info("Updating from myAir")
 
-        try:
-            await self.myair_client.connect()
-        except AuthenticationError as e:
-            _LOGGER.error("Authentication Error while updating. %s: %s", type(e).__name__, e)
-            raise ConfigEntryAuthFailed(
-                f"Authentication Error while updating. {type(e).__name__}: {e}"
-            ) from e
+        await self._async_connect()
 
         device: MyAirDevice | None = None
         sleep_records: tuple[MyAirSleepRecord, ...] = ()
@@ -76,6 +67,18 @@ class MyAirDataUpdateCoordinator(DataUpdateCoordinator[MyAirCoordinatorData]):
                 type(err).__name__,
                 err,
             )
+            _LOGGER.info(
+                "Device payload missing after token validation; retrying with fresh authentication"
+            )
+            await self._async_connect(force=True)
+            try:
+                device = await self.myair_client.get_user_device_data()
+            except ParsingError as retry_err:
+                _LOGGER.debug(
+                    "Device data unavailable after fresh authentication. %s: %s",
+                    type(retry_err).__name__,
+                    retry_err,
+                )
 
         try:
             sleep_records = tuple(await self.myair_client.get_sleep_records())
@@ -87,3 +90,28 @@ class MyAirDataUpdateCoordinator(DataUpdateCoordinator[MyAirCoordinatorData]):
             )
 
         return MyAirCoordinatorData(device=device, sleep_records=sleep_records)
+
+    async def _async_connect(self, *, force: bool = False) -> None:
+        """Authenticate for a coordinator refresh and map auth failures.
+
+        Args:
+            force (bool): Whether to bypass cached-token validation and authenticate
+                again.
+
+        Raises:
+            ConfigEntryAuthFailed: When myAir authentication requires user repair.
+        """
+        try:
+            if force:
+                await self.myair_client.connect(force=True)
+            else:
+                await self.myair_client.connect()
+        except AuthenticationError as err:
+            _LOGGER.error(
+                "Authentication Error while updating. %s: %s",
+                type(err).__name__,
+                err,
+            )
+            raise ConfigEntryAuthFailed(
+                f"Authentication Error while updating. {type(err).__name__}: {err}"
+            ) from err

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,7 +1,7 @@
 """Coordinator tests that protect refresh, auth, and parse fallbacks."""
 
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
 import pytest
@@ -65,6 +65,36 @@ async def test_async_update_data_auth_error(hass: MagicMock, myair_client: Magic
     myair_client.connect.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_async_update_data_reauthenticates_after_missing_device(
+    hass: MagicMock, myair_client: MagicMock
+) -> None:
+    """A missing device payload forces fresh authentication and one retry.
+
+    Args:
+        hass (MagicMock): Home Assistant instance supplied to the coordinator.
+        myair_client (MagicMock): Client double simulating a stale data-API token.
+    """
+    expected_device = MyAirDevice.from_api(
+        {"serialNumber": "1234", "fgDeviceManufacturerName": "ResMed"}
+    )
+    expected_records = [MyAirSleepRecord.from_api({"totalUsage": 60, "startDate": "2024-07-01"})]
+    myair_client.get_user_device_data.side_effect = [
+        ParsingError("device payload missing"),
+        expected_device,
+    ]
+    myair_client.get_sleep_records.return_value = expected_records
+
+    coordinator = MyAirDataUpdateCoordinator(hass, MagicMock(), myair_client)
+    data = await coordinator._async_update_data()
+
+    assert data.device is expected_device
+    assert data.sleep_records == tuple(expected_records)
+    assert myair_client.connect.await_args_list == [call(), call(force=True)]
+    assert myair_client.get_user_device_data.await_count == 2
+    myair_client.get_sleep_records.assert_awaited_once()
+
+
 @pytest.mark.parametrize("failing_fetch", ["device", "sleep_records"])
 @pytest.mark.asyncio
 async def test_async_update_data_parsing_error_variants(
@@ -104,6 +134,8 @@ async def test_async_update_data_parsing_error_variants(
             "Device data unavailable in myAir update. ParsingError: device parse fail"
             in caplog.text
         )
+        assert myair_client.connect.await_args_list == [call(), call(force=True)]
+        assert myair_client.get_user_device_data.await_count == 2
     else:
         assert data.device is expected_device
         assert data.sleep_records == ()
@@ -111,7 +143,7 @@ async def test_async_update_data_parsing_error_variants(
             "Sleep record data unavailable in myAir update. ParsingError: sleep parse fail"
             in caplog.text
         )
+        myair_client.connect.assert_awaited_once()
+        myair_client.get_user_device_data.assert_awaited_once()
 
-    myair_client.connect.assert_awaited_once()
-    myair_client.get_user_device_data.assert_awaited_once()
     myair_client.get_sleep_records.assert_awaited_once()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,7 +6,11 @@ from unittest.mock import MagicMock, call
 from homeassistant.exceptions import ConfigEntryAuthFailed
 import pytest
 
-from custom_components.resmed_myair.client.myair_client import AuthenticationError, ParsingError
+from custom_components.resmed_myair.client.myair_client import (
+    AuthenticationError,
+    ParsingError,
+    StaleSessionError,
+)
 from custom_components.resmed_myair.coordinator import MyAirDataUpdateCoordinator
 from custom_components.resmed_myair.models import (
     MyAirCoordinatorData,
@@ -80,7 +84,7 @@ async def test_async_update_data_reauthenticates_after_missing_device(
     )
     expected_records = [MyAirSleepRecord.from_api({"totalUsage": 60, "startDate": "2024-07-01"})]
     myair_client.get_user_device_data.side_effect = [
-        ParsingError("device payload missing"),
+        StaleSessionError("device payload missing"),
         expected_device,
     ]
     myair_client.get_sleep_records.return_value = expected_records
@@ -93,6 +97,89 @@ async def test_async_update_data_reauthenticates_after_missing_device(
     assert myair_client.connect.await_args_list == [call(), call(force=True)]
     assert myair_client.get_user_device_data.await_count == 2
     myair_client.get_sleep_records.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_reauthenticates_after_stale_sleep_response(
+    hass: MagicMock, myair_client: MagicMock
+) -> None:
+    """A stale sleep response uses the one forced login allowed per refresh.
+
+    Args:
+        hass (MagicMock): Home Assistant instance supplied to the coordinator.
+        myair_client (MagicMock): Client double simulating a stale sleep query.
+    """
+    expected_device = MyAirDevice.from_api(
+        {"serialNumber": "1234", "fgDeviceManufacturerName": "ResMed"}
+    )
+    expected_records = [MyAirSleepRecord.from_api({"totalUsage": 60})]
+    myair_client.get_user_device_data.return_value = expected_device
+    myair_client.get_sleep_records.side_effect = [
+        StaleSessionError("sleep payload missing"),
+        expected_records,
+    ]
+
+    coordinator = MyAirDataUpdateCoordinator(hass, MagicMock(), myair_client)
+    data = await coordinator._async_update_data()
+
+    assert data.device is expected_device
+    assert data.sleep_records == tuple(expected_records)
+    assert myair_client.connect.await_args_list == [call(), call(force=True)]
+    myair_client.get_user_device_data.assert_awaited_once()
+    assert myair_client.get_sleep_records.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_limits_stale_recovery_to_one_login(
+    hass: MagicMock, myair_client: MagicMock
+) -> None:
+    """One refresh never performs more than one forced authentication.
+
+    Args:
+        hass (MagicMock): Home Assistant instance supplied to the coordinator.
+        myair_client (MagicMock): Client double returning repeated stale responses.
+    """
+    myair_client.get_user_device_data.side_effect = [
+        StaleSessionError("device payload missing"),
+        ParsingError("device still unavailable"),
+    ]
+    myair_client.get_sleep_records.side_effect = StaleSessionError("sleep payload missing")
+
+    coordinator = MyAirDataUpdateCoordinator(hass, MagicMock(), myair_client)
+    data = await coordinator._async_update_data()
+
+    assert data.device is None
+    assert data.sleep_records == ()
+    assert myair_client.connect.await_args_list == [call(), call(force=True)]
+    assert myair_client.get_user_device_data.await_count == 2
+    myair_client.get_sleep_records.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_degrades_when_stale_sleep_retry_fails(
+    hass: MagicMock, myair_client: MagicMock
+) -> None:
+    """A malformed sleep retry degrades without another authentication attempt.
+
+    Args:
+        hass (MagicMock): Home Assistant instance supplied to the coordinator.
+        myair_client (MagicMock): Client double whose retried sleep query fails.
+    """
+    expected_device = MyAirDevice.from_api({"serialNumber": "1234"})
+    myair_client.get_user_device_data.return_value = expected_device
+    myair_client.get_sleep_records.side_effect = [
+        StaleSessionError("sleep payload missing"),
+        ParsingError("sleep still unavailable"),
+    ]
+
+    coordinator = MyAirDataUpdateCoordinator(hass, MagicMock(), myair_client)
+    data = await coordinator._async_update_data()
+
+    assert data.device is expected_device
+    assert data.sleep_records == ()
+    assert myair_client.connect.await_args_list == [call(), call(force=True)]
+    myair_client.get_user_device_data.assert_awaited_once()
+    assert myair_client.get_sleep_records.await_count == 2
 
 
 @pytest.mark.parametrize("failing_fetch", ["device", "sleep_records"])
@@ -134,8 +221,8 @@ async def test_async_update_data_parsing_error_variants(
             "Device data unavailable in myAir update. ParsingError: device parse fail"
             in caplog.text
         )
-        assert myair_client.connect.await_args_list == [call(), call(force=True)]
-        assert myair_client.get_user_device_data.await_count == 2
+        myair_client.connect.assert_awaited_once()
+        myair_client.get_user_device_data.assert_awaited_once()
     else:
         assert data.device is expected_device
         assert data.sleep_records == ()

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -552,6 +552,35 @@ async def test_connect_authn_success(
 
 
 @pytest.mark.asyncio
+async def test_connect_force_bypasses_active_token(
+    config_na: MyAirConfig, session: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Forced connections authenticate without trusting token introspection.
+
+    Args:
+        config_na (MyAirConfig): Client configuration used by the connection.
+        session (MagicMock): HTTP session stand-in supplied to the client.
+        monkeypatch (pytest.MonkeyPatch): Patching fixture for the auth flow.
+    """
+    client = RESTClient(config_na, session)
+    client._auth.device_token = "dt"
+    client._auth.access_token = "token"
+    is_active_mock = AsyncMock(return_value=True)
+    authn_mock = AsyncMock(return_value="SUCCESS")
+    get_access_token_mock = AsyncMock()
+    monkeypatch.setattr(client._auth, "_is_access_token_active", is_active_mock)
+    monkeypatch.setattr(client._auth, "_authn_check", authn_mock)
+    monkeypatch.setattr(client._auth, "_get_access_token", get_access_token_mock)
+
+    result = await client.connect(force=True)
+
+    assert result == "SUCCESS"
+    is_active_mock.assert_not_awaited()
+    authn_mock.assert_awaited_once()
+    get_access_token_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("initial", "expect_trigger", "expect_result", "expect_raises"),
     [

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -17,6 +17,7 @@ from custom_components.resmed_myair.client.myair_client import (
     AuthenticationError,
     IncompleteAccountError,
     MyAirConfig,
+    StaleSessionError,
 )
 from custom_components.resmed_myair.client.regions import (
     EU_CONFIG,
@@ -730,8 +731,8 @@ async def test_connect_status_needs_mfa_parametrized(
 
 
 @pytest.mark.asyncio
-async def test_resmed_response_error_check_gql_query_not_initial_raises_parsing_error() -> None:
-    """Unauthorized GraphQL errors during refresh raise `ParsingError`."""
+async def test_resmed_response_error_check_gql_query_not_initial_raises_stale_session() -> None:
+    """Unauthorized GraphQL errors during refresh mark the session as stale."""
     # Prepare a fake response and error dict
     response = MagicMock(spec=ClientResponse)
     response.status = 401
@@ -739,7 +740,7 @@ async def test_resmed_response_error_check_gql_query_not_initial_raises_parsing_
 
     resp_dict = {"errors": [{"errorInfo": {"errorType": "unauthorized", "errorCode": "401"}}]}
 
-    with pytest.raises(ParsingError) as exc:
+    with pytest.raises(StaleSessionError) as exc:
         await MyAirAuthSession.resmed_response_error_check(
             step="gql_query", response=response, resp_dict=resp_dict, initial=False
         )
@@ -1407,7 +1408,7 @@ async def test_gql_query_graphql_error(config_na: MyAirConfig, session: MagicMoc
     )
 
     session.post.return_value = make_mock_aiohttp_context_manager(mock_res)
-    with pytest.raises(ParsingError, match="unauthorized: 401"):
+    with pytest.raises(StaleSessionError, match="unauthorized: 401"):
         await client._gql_query("op", "query")
 
 
@@ -1631,6 +1632,7 @@ async def test_get_sleep_records_raises_parsing_error_for_non_mapping_items(
 @pytest.mark.parametrize(
     ("mock_response", "match_msg"),
     [
+        ({"data": "not-a-mapping"}, "Error getting User Device Data"),
         ({"data": {"getPatientWrapper": {}}}, "Error getting User Device Data"),
         (
             {"data": {"getPatientWrapper": {"fgDevices": []}}},
@@ -1677,6 +1679,27 @@ async def test_get_user_device_data_failure_variants(
     monkeypatch.setattr(client, "_gql_query", AsyncMock(return_value=mock_response))
     with pytest.raises(ParsingError, match=match_msg):
         await client.get_user_device_data()
+
+
+@pytest.mark.asyncio
+async def test_get_user_device_data_empty_list_is_not_stale_session(
+    config_na: MyAirConfig, session: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A present but empty device list remains a non-auth parsing failure.
+
+    Args:
+        config_na (MyAirConfig): Client configuration used by the data fetch.
+        session (MagicMock): HTTP session stand-in supplied to the client.
+        monkeypatch (pytest.MonkeyPatch): Patching fixture for the GraphQL query.
+    """
+    client = RESTClient(config_na, session)
+    response = {"data": {"getPatientWrapper": {"fgDevices": []}}}
+    monkeypatch.setattr(client, "_gql_query", AsyncMock(return_value=response))
+
+    with pytest.raises(ParsingError) as exc:
+        await client.get_user_device_data()
+
+    assert type(exc.value) is ParsingError
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Improves resilience when myAir returns an incomplete payload for a token that Okta still reports as active.

## What Changed

- Added a forced-authentication option that bypasses cached-token introspection.
- Retry device and sleep-data retrieval once with fresh authentication when a validated session returns a missing payload.
- Keep malformed payloads and legitimately empty record lists distinct from stale-session failures.
- Added regression coverage for stale-session recovery, forced authentication, and persistent parsing failures.

## Why

The data API can stop returning device and sleep data even while Okta introspection reports the access token as active. Retrying once after fresh authentication prevents a full polling-cycle outage without treating legitimately empty sleep-record lists as authentication failures.

## Related Issues

Closes #170