### PR TITLE
Fix Dependabot updates for HA-pinned tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,21 @@ updates:
       python-dependencies:
         patterns:
           - "*"
+    ignore:
+      # Ignore routine updates by type instead of ignoring each dependency
+      # completely, so Dependabot security updates remain enabled.
+      # Home Assistant pins the compatible uv version.
+      - dependency-name: "uv"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      # pytest-homeassistant-custom-component pins the compatible pytest version.
+      - dependency-name: "pytest"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     open-pull-requests-limit: 1
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

Prevents routine Dependabot updates from independently advancing `uv` and `pytest` beyond the exact versions required by the Home Assistant development toolchain.

## What Changed

- Ignore routine major, minor, and patch updates for `uv`
- Ignore routine major, minor, and patch updates for `pytest`
- Preserve Dependabot security updates by limiting the ignore rules to version-update types

## Why

Home Assistant pins the compatible `uv` version, while `pytest-homeassistant-custom-component` pins the compatible `pytest` version. Dependabot attempted to update both tools independently, producing an unsatisfiable dependency graph instead of a usable update.