### PR TITLE
Lock inactive closed issues

### DIFF
--- a/.github/workflows/lock_closed_issues.yml
+++ b/.github/workflows/lock_closed_issues.yml
@@ -1,0 +1,25 @@
+name: "Lock Closed Issues"
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  action:
+    name: Lock Closed Issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lock closed issues
+        uses: dessant/lock-threads@v6
+        with:
+          issue-inactive-days: "7"
+          issue-lock-reason: "resolved"
+          process-only: "issues"
+          log-output: true

--- a/.github/workflows/lock_closed_issues.yml
+++ b/.github/workflows/lock_closed_issues.yml
@@ -10,6 +10,7 @@ permissions:
 
 concurrency:
   group: lock-threads
+  cancel-in-progress: true
 
 jobs:
   action:

--- a/prek.toml
+++ b/prek.toml
@@ -30,6 +30,7 @@ rev = "v1.7.12"
 
 [[repos.hooks]]
 id = "actionlint"
+require_serial = true
 additional_dependencies = [
   "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1",
 ]


### PR DESCRIPTION
## Summary

Adds automated maintenance for closed issues by locking them after seven days of inactivity. The workflow can also be run manually when needed.

## What Changed

- Added a daily GitHub Actions schedule for closed-issue maintenance
- Configured `dessant/lock-threads@v6` to process issues only
- Locks inactive closed issues with the `resolved` reason
- Granted only the `issues: write` permission required by the action
- Serialized workflow runs through a dedicated concurrency group

## Why

Locking resolved issues after a short inactivity period keeps completed discussions stable while leaving a seven-day window for follow-up. Manual dispatch provides an operator-controlled fallback without broadening the workflow's scope.